### PR TITLE
Suggested edits to github read-me documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 Your development system must have:
 
 * MacOS, Linux, or WSL (Windows Subsystem for Linux)
-* mongodb (100.5.2 or better)
-* mongodb database tools (4.x or better)
-* nodejs (16.x)
-* imagemagick command line utilities
+* MongoDB (4.x or better)
+* [MongoDB Database Tools](https://www.mongodb.com/try/download/database-tools)
+* [nodejs (16.x)](https://nodejs.org/en/download/)
+* [imagemagick](https://imagemagick.org/index.php) command line utilities
+
+For more information on installing MongoDB see instruction below.
   
 
 ## Developing on Windows in WSL 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,24 @@
 # pa-wildflower-selector
 
-## Dev system requirements
+## System requirements
 
 Your development system must have:
 
-* MacOS, Linux, or Windows Subsystem for Linux (not the Windows command prompt)
-* mongodb (4.x or better)
+* MacOS, Linux, or WSL (Windows Subsystem for Linux)
+* mongodb (100.5.2 or better)
+* mongodb database tools (4.x or better)
 * nodejs (16.x)
 * imagemagick command line utilities
-
-## Production system requirements
-
-* Linux
-* mongodb (4.x or better)
-* nodejs (16.x)
-* imagemagick command line utilities
+  
 
 ## Developing on Windows in WSL 
 
-First, make sure the that you have WSL installed on your system and that you're using version 2. 
-You can check both of these requirements by running ```wsl -l -v``` in your Powershell Terminal or Commmand Prompt. 
-If this returns an error follow the instructions [here](https://docs.microsoft.com/en-us/windows/wsl/install). 
+[Windows Subsystem for Linux, or WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) is a service provided to developers that allows a Windows 10 user to have a full Linux kernel installed and running in a virtual machine under the hood, allowing for access to a complete Unix filesystem and command line while continuing to use Windows GUI apps.
 
-WSL comes with an outdated version of Node. Run the following commands in your WSL shell to remove node, install a node version manager and install 
-the latest stable version of node ([reference](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)). 
+First, make sure the that you have WSL installed on your system and that you're using version 2. 
+You can check both of these requirements by running ```wsl -l -v``` in your Powershell Terminal or Commmand Prompt. If this returns an error follow the instructions [here](https://docs.microsoft.com/en-us/windows/wsl/install). 
+
+WSL comes with an outdated version of Node. Run the following commands in your WSL shell to remove node, install a node version manager and install the latest stable version of node ([reference](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)). 
 
 ```
 sudo apt-get purge --auto-remove nodejs
@@ -36,56 +31,58 @@ nvm install --lts
 nvm ls
 ```
 
-There are many ways to download Mongo but Microsoft [suggests](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database) doing so in the following steps: 
 
-```
-cd ~
-sudo apt update
-wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
-sudo apt-get update
-sudo apt-get install -y mongodb-org
 
-mongod --version
-```
+## Install MongoDB on Windows
 
-A commonly missed step is not creating a directory for mongo to write to (this step my not be listed in other instructions because the directory is created during installation on Mac OS and Linux). 
+Installing MongoDB on Windows instructions on Microsoft website. Scroll down to Install MongoDB section at: https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database
 
-```
-mkdir -p ~/data/db
-sudo chown -R `id -un` ~/data/db
-```
+## Install MongoDB on Mac OS
 
-Run a Mongo instance: 
-
-```
-sudo mongod --dbpath ~/data/db
-```
-
-Open a new terminal to continue with instructions from here. 
+Installation of MongoDB Community Edition instructions for Mac OS can be found on the MongoDB website at: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/
 
 ## Project setup
 
-First install the imagemagick command line utilities and MongoDB community edition on your machine, including the MongoDB command line utilities.
+In a new terminal windows:
 
-Next clone the project:
+###  Clone the project:
 
 ```
 git clone https://github.com/CodeForPhilly/pa-wildflower-selector
 ```
 
-Then you can install the npm dependencies at the server app and ui app levels:
+### Install the npm dependencies:
 
 ```
 cd pa-wildflower-selector
 npm install
 ```
 
-## First time and occasional stuff
+### Start up both a local server and the frontend app
+
+```
+npm run dev
+```
+
+### Compile and minify project for production
+
+```
+npm run build
+```
+
+### Tests the production experience locally
+
+```
+npm run ssr-dev
+```
+
+This is much slower and doesn't restart automatically, but it is important to check before deploying to production, in order to make sure we haven't broken server side rendering with changes to the Vue application that are browser-specific. If you must do something browser-specific, wrap it in an `if ((typeof window) !== 'undefined') { ... }` block.
+
+
 
 ### Download a copy of the database
 
-Run:
+### Run:
 
 ```
 npm run restore-test-data
@@ -107,37 +104,7 @@ npm run fast-update-data
 
 Significantly faster, but **skips images**, so use it only if you already have the images you need.
 
-## Routine stuff
 
-### Start up both a local server and the frontend app
-```
-npm run dev
-```
-
-### Compiles and minifies for production
-```
-npm run build
-```
-
-### Tests the production experience locally
-```
-npm run ssr-dev
-```
-
-This is much slower and doesn't restart automatically, but it is important to check before deploying to production, in order to make sure we haven't broken server side rendering with changes to the Vue application that are browser-specific. If you must do something browser-specific, wrap it in an `if ((typeof window) !== 'undefined') { ... }` block.
-
-### Deploys (to Tom's server, currently for Tom to run)
-```
-npm run deploy
-```
-
-### Where is the UI code?
-
-In `src/`.
-
-### Where is the server-side app code that answers queries?
-
-In the main folder of the project.
 
 ## Running with Docker Compose
 
@@ -207,6 +174,8 @@ This command both shuts down the local server AND erases all local state:
 docker-compose down -v
 ```
 
-## Open Questions
 
-- Does the deploy need two copies of the entire dist/ directory copied into both public/ and ssr/ ?
+
+## Help us improve these instructions
+
+Please open an issue if you have a question or improvement about these instructions: https://github.com/CodeForPhilly/pa-wildflower-selector/issues

--- a/README.md
+++ b/README.md
@@ -114,11 +114,7 @@ For local development, `docker-compose` is used to create a consistent and dispo
 
 [GitHub's  `Scripts To Rule Them All` pattern](https://github.com/github/scripts-to-rule-them-all) is leveraged to provide simple commands with reasonable default behavior for common developer steps.
 
-From within the project folder, run command:
-
-```
-docker-compose up
-```
+Make sure docker is installed and running. For info on installing docker go to: https://docs.docker.com/compose/install/. Once docker is installed, you can use the GitHub script commands below to run the docker environment on your local machine.
 
 ### Start server
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Your development system must have:
 * [imagemagick](https://imagemagick.org/index.php) command line utilities
 
 For more information on installing MongoDB see instruction below.
-  
+
 
 ## Developing on Windows in WSL 
 
@@ -113,6 +113,12 @@ Significantly faster, but **skips images**, so use it only if you already have t
 For local development, `docker-compose` is used to create a consistent and disposable environment without any modification to or dependency on software installed to the developer's workstation. This approach also provides close parity between local development and container-based deployment in production to Kubernetes.
 
 [GitHub's  `Scripts To Rule Them All` pattern](https://github.com/github/scripts-to-rule-them-all) is leveraged to provide simple commands with reasonable default behavior for common developer steps.
+
+From within the project folder, run command:
+
+```
+docker-compose up
+```
 
 ### Start server
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,16 @@ export default {
 };
 </script>
 
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-CHCN0FC8JD"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-CHCN0FC8JD');
+</script>
+
 <style>
 html {
   box-sizing: border-box;
@@ -166,13 +176,13 @@ body {
   font-feature-settings: 'liga';
 
   vertical-align: middle;
-  
+
   font-size: 120%;
 }
 
 .material-align {
   display: inline-flex;
-  vertical-align: bottom;  
+  vertical-align: bottom;
 }
 
 @media all and (min-width: 1280px) {


### PR DESCRIPTION
These suggested edits attempt to shorten the documentation, remove unnecessary text, clarify terms, add consistent styling, and be open to more suggestions 

My Notes on PA Native plants GitHub docs suggested edits to text:

1. I forked repo
2. Reading Dev System Requirements
- What does it mean to “have” mongodb?
- Does one really really need imagemagick command line utilities? If yes why? Can they use photoshop?

3. Reading Production system requirements…not sure why this section is needed especially since the requirements are the same as the Dev system requirements…

Not sure what “not the windows command prompt means” if it’s needed here

3.5 Add a section about MongoDB stating that it can be downloaded for Mac OS but for Windows you need WSL? Then go into setting up WSL and downloading MongoDB for WSL.

“Windows Subsystem for Linux, or WSL is a service provided to developers that allows a Windows 10 user to have a full Linux kernel installed and running in a virtual machine under the hood, allowing for access to a complete Unix filesystem and command line while continuing to use Windows GUI apps.” 

https://dev.to/seanwelshbrown/installing-mongodb-on-windows-subsystem-for-linux-wsl-2-19m9

4. Reading Developing on Windows in WSL 
https://www.freecodecamp.org/news/how-to-run-linux-apps-on-windows-10-11-using-wsl/
- Might be worth it to spell out WSL on more time for this section. 
- Maybe rename “Developing on Windows in WSL” to Install MonogoDB on Windows using WSL?

- In Instructions at sentence “There are may ways to download Mongo” reword to say MongoDB or is Mongo common shorthand for MongoDB? 

- Maybe not have instructions on how to install “MongoDB using WSL in our GitHub instructions but refer them to the Get started with databases on Windows Subsystem for Linux: https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database
- Keep note about “common mistake” for windows. Say on Mac OS and Linux a directory is creating automatically on install. 

- And then a heading for Install MongoDB for MacOS?
- Have link to install instructions - https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/

5. Project setup
- No need to say install imagemagick since it’s listed in system requirements. Maybe add MongoDB utilities in system requirements too. Or list here if you really feel like people won’t install MongoDB command line utilities. Are the MongoDB command line utilities the same as MongoDB Database Tools which on Mac OS gets downloaded when the MongoDB gets downloaded. 

https://www.mongodb.com/try/download/database-tools

6. Deploys (to Tom’s server…) - probably will need to update when Tom semi-retires.

7. No need to have questions “Where is UI code and server-side app code..” If person knows Vue.js then they should know where UI code is etc. 

8. Not sure what Open questions is maybe belongs as an issue? Or rename Open questions to FAQ?