### PR TITLE
Adding google analytics tracking script tag

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,16 @@ export default {
 };
 </script>
 
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-CHCN0FC8JD"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-CHCN0FC8JD');
+</script>
+
 <style>
 html {
   box-sizing: border-box;


### PR DESCRIPTION
Adding google analytics tracking script tag because we discussed that this would be good to do before launching the website. The email account associated with this google analytics tag is choosenativeplantsapp@gmail.com. 