### PR TITLE
83 project set up scripts arent os agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Your development system must have:
 
-* MacOS, Linux, or Windows Subsystem for Linux (not the Windows command prompt)
+* MacOS, Linux, or Windows
 * mongodb (4.x or better)
 * nodejs (16.x)
 * imagemagick command line utilities
@@ -16,14 +16,7 @@ Your development system must have:
 * nodejs (16.x)
 * imagemagick command line utilities
 
-## Developing on Windows in WSL 
 
-First, make sure the that you have WSL installed on your system and that you're using version 2. 
-You can check both of these requirements by running ```wsl -l -v``` in your Powershell Terminal or Commmand Prompt. 
-If this returns an error follow the instructions [here](https://docs.microsoft.com/en-us/windows/wsl/install). 
-
-WSL comes with an outdated version of Node. Run the following commands in your WSL shell to remove node, install a node version manager and install 
-the latest stable version of node ([reference](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)). 
 
 ```
 sudo apt-get purge --auto-remove nodejs
@@ -36,7 +29,8 @@ nvm install --lts
 nvm ls
 ```
 
-There are many ways to download Mongo but Microsoft [suggests](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database) doing so in the following steps: 
+#### Install Mongo
+##### For Mac Users
 
 ```
 cd ~
@@ -49,18 +43,31 @@ sudo apt-get install -y mongodb-org
 mongod --version
 ```
 
-A commonly missed step is not creating a directory for mongo to write to (this step my not be listed in other instructions because the directory is created during installation on Mac OS and Linux). 
+##### For Windows Users
+Download and install MongoDB Community Server, Mongo Shell, and Mongo Tools.
+https://www.mongodb.com/try/download/community
+https://www.mongodb.com/try/download/shell
+https://www.mongodb.com/try/download/database-tools
+
+Install Windows MongoDB Community Edition. “Install MongoD as a Service” and keep the default “Run service as Network Service user”. There is no need to install MongoDB Compass.
+
+#### Run a Mongo instance:
+##### For Mac Users
+Run a Mongo instance:
 
 ```
 mkdir -p ~/data/db
 sudo chown -R `id -un` ~/data/db
-```
-
-Run a Mongo instance: 
-
-```
 sudo mongod --dbpath ~/data/db
 ```
+
+##### For Windows Users
+Run a Mongo instance:
+
+```
+mongosh mongodb://localhost:27017/pa-wildflower-selector
+```
+
 
 Open a new terminal to continue with instructions from here. 
 
@@ -97,6 +104,7 @@ On Windows
 ```
 npm run restore-test-data-win
 ```
+
 
 
 You can also rebuild it from scratch, but this takes hours to run because of the need to obtain images from wikipedia and wikimedia.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Your development system must have:
 * MacOS, Linux, or Windows
 * mongodb (4.x or better)
 * nodejs (16.x)
-* imagemagick command line utilities
+* imagemagick command line utilities (only needed if making new set of plant images)
 
 ## Production system requirements
 
@@ -16,18 +16,25 @@ Your development system must have:
 * nodejs (16.x)
 * imagemagick command line utilities
 
+### Node.js Installation Instructions
+Overview
+This section provides detailed steps for installing Node.js on both Mac and Windows operating systems. Please follow the instructions specific to your operating system.
 
 
+* nodejs (v20.10.0). Run node -v to confirm.
+
+** Update node by running: 
 ```
-sudo apt-get purge --auto-remove nodejs
-
-sudo apt-get install curl
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-command -v nvm
-
-nvm install --lts
-nvm ls
+sudo npm cache clean -f # Clears (force) your npm cache
+sudo npm install -g n # Install n
+sudo n stable # Upgrade to the current stable version
 ```
+
+##### For Windows Users
+Download Latest LTS Version: 20.10.0
+https://nodejs.org/en/download/
+
+
 
 #### Install Mongo
 ##### For Mac Users
@@ -104,8 +111,6 @@ On Windows
 ```
 npm run restore-test-data-win
 ```
-
-
 
 You can also rebuild it from scratch, but this takes hours to run because of the need to obtain images from wikipedia and wikimedia.
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,17 @@ npm install
 
 Run:
 
+On Mac/Linux:
+
 ```
 npm run restore-test-data
 ```
+
+On Windows
+```
+npm run restore-test-data-win
+```
+
 
 You can also rebuild it from scratch, but this takes hours to run because of the need to obtain images from wikipedia and wikimedia.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "sign-secrets": "./script/sign-secrets",
     "upload-test-data": "./scripts/upload-test-data",
     "restore-test-data": "./scripts/restore-test-data",
+    "restore-test-data-win": "./scripts/restore-test-data.js",
     "update-data": "node download && node massage",
     "fast-update-data": "node download --skip-images && node massage"
   },

--- a/scripts/restore-test-data.js
+++ b/scripts/restore-test-data.js
@@ -1,0 +1,98 @@
+const https = require('https');
+const { spawn } = require('child_process');
+const zlib = require('zlib');
+const tar = require('tar');
+const fs = require('fs');
+
+// Function to check if a command exists
+function commandExists(command) {
+  return new Promise((resolve, reject) => {
+    const process = spawn(command, ['--version'], { shell: true });
+
+    let found = false; // Flag to check if command outputs anything
+
+    process.stdout.on('data', (data) => {
+      if (data.toString()) {
+        found = true;
+      }
+    });
+
+    process.on('error', (err) => {
+      reject(err); // Some other error
+    });
+
+    process.on('exit', (code) => {
+      resolve(found); // Resolve based on the found flag, true if command outputs anything
+    });
+  });
+}
+
+function downloadAndSave(url, filePath) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(filePath);
+    https.get(url, res => {
+      res.pipe(file)
+        .on('close', resolve)
+        .on('error', reject);
+    });
+  });
+}
+
+function decompressGZAndRestore(filePath, restoreCommand) {
+  return new Promise((resolve, reject) => {
+    const restoreProcess = spawn(restoreCommand, { shell: true });
+
+    restoreProcess.on('error', (err) => {
+      reject(new Error(`'${restoreCommand.split(' ')[0]}' command error: ${err.message}. Ensure the command is correct and MongoDB Database Tools are installed and accessible.`));
+    });
+
+    restoreProcess.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Restore process exited with code ${code}. Ensure the command is correct and MongoDB Database Tools are installed and accessible.`));
+      } else {
+        resolve();
+      }
+    });
+
+    fs.createReadStream(filePath)
+      .pipe(zlib.createGunzip())
+      .pipe(restoreProcess.stdin)
+      .on('error', (error) => {
+        // Handle EPIPE or other stream errors
+        reject(new Error(`Error piping data to '${restoreCommand}': ${error.message}`));
+      });
+  });
+}
+
+function downloadAndExtractTar(url, extractPath) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      res.pipe(tar.x({ C: extractPath }))
+        .on('finish', resolve)
+        .on('error', reject);
+    });
+  });
+}
+
+// Beginning of your script logic
+commandExists('mongorestore')
+  .then(mongorestoreExists => {
+    if (!mongorestoreExists) {
+      console.error('Error: "mongorestore" command not found. Please ensure MongoDB Database Tools are installed and accessible in your PATH.');
+      process.exit(1); // Exit with an error code
+    }
+
+    // If mongorestore exists, continue with the rest of your script's logic:
+    downloadAndSave('https://boutell.dev/pa-wildflower-selector/pa-wildflower-selector.archive.gz', 'pa-wildflower-selector.archive.gz')
+      .then(() => console.log('Compressed test data downloaded locally. Starting MongoDB restore.'))
+      .then(() => decompressGZAndRestore('pa-wildflower-selector.archive.gz', 'mongorestore --drop --archive'))
+      .then(() => console.log('Restored test data to MongoDB.'))
+      .catch(err => console.error(`Error: ${err.message}`));
+
+    downloadAndExtractTar('https://boutell.dev/pa-wildflower-selector/pa-wildflower-selector.tar', '.')
+      .then(() => console.log('Test data downloaded and extracted.'))
+      .catch(err => console.error(`Error: ${err.message}`));
+  })
+  .catch(err => {
+    console.error(`Error checking for "mongorestore": ${err.message}`);
+  });

--- a/scripts/restore-test-data.js
+++ b/scripts/restore-test-data.js
@@ -78,7 +78,7 @@ function downloadAndExtractTar(url, extractPath) {
 commandExists('mongorestore')
   .then(mongorestoreExists => {
     if (!mongorestoreExists) {
-      console.error('Error: "mongorestore" command not found. Please ensure MongoDB Database Tools are installed and accessible in your PATH.');
+      console.error('Error: "mongorestore" command not found. Please ensure MongoDB Database Tools are installed and accessible in your PATH. https://www.mongodb.com/try/download/database-tools');
       process.exit(1); // Exit with an error code
     }
 


### PR DESCRIPTION
I added "npm run restore-test-data-win" as "npm run restore-test-data" did not run in Windows.
"npm run restore-test-data-win" is os agnostic as it relies on a js script. This is tested on my windows machine.

This pull request is for the js script, package.json reference, and readme update.

Evidence of this running locally:
![image](https://github.com/CodeForPhilly/pa-wildflower-selector/assets/54847203/95686f58-9675-4beb-af72-07b050d613eb)
![image](https://github.com/CodeForPhilly/pa-wildflower-selector/assets/54847203/21fe1db4-227b-4710-850e-bf754a1dd7af)

