### PR TITLE
added missing PAC_API_BASE_URL name in YAML

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -162,7 +162,8 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: pac_api
-                  key
+                  key: PAC_API_BASE_URL
+                  optional: false
           envFrom:
             - configMapRef:
                 name: app-config


### PR DESCRIPTION
This pull request includes a small but important change to the `helm-chart/templates/deployment.yaml` file. The change specifies the `key` and `optional` fields for the `secretKeyRef` configuration.

* [`helm-chart/templates/deployment.yaml`](diffhunk://#diff-d9f1284d8f1fd26863dca5b0ea8d327acc364fb7596ced1f0092eae83bba0818L165-R166): Added `key: PAC_API_BASE_URL` and `optional: false` to the `secretKeyRef` configuration to ensure the correct environment variable is referenced and it is mandatory.