### PR TITLE
Fix hydration mismatch in Explorer component

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -845,7 +845,7 @@ export default {
 
     this.initQuestionValues(questionDetails);
 
-    const twoUpIndex = Math.floor(Math.random() * twoUpImageCredits.length);
+    const twoUpIndex = 0;
     return {
       results: [],
       total: 0,
@@ -1026,6 +1026,8 @@ export default {
   },
   // Browser only
   async mounted() {
+    // Pick a random hero image after hydration to avoid SSR hydration mismatch
+    this.twoUpIndex = Math.floor(Math.random() * twoUpImageCredits.length);
     this.displayLocation = localStorage.getItem("displayLocation")
     this.zipCode= localStorage.getItem("zipCode")
     this.filterValues["States"] = [localStorage.getItem("state")]


### PR DESCRIPTION
## Summary
- avoid random hero selection during SSR
- randomize hero image only after the client has mounted

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*