### PR TITLE
Fix PVC breaking change for 2.0.4 release

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.0
+appVersion: 2.0.4

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -31,10 +31,10 @@ spec:
       volumes:
       - name: {{ .Release.Name }}-app-images
         persistentVolumeClaim:
-          claimName: {{ .Values.existingPVCs.appImages | default (printf "%s-app-images" .Release.Name) }}
+          claimName: {{ printf "%s-app-images" .Release.Name }}
       - name: {{ .Release.Name }}-mongo-data
         persistentVolumeClaim:
-          claimName: {{ .Values.existingPVCs.mongoData | default (printf "%s-mongo-data" .Release.Name) }}
+          claimName: {{ printf "%s-mongo-data" .Release.Name }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-chart/templates/pvc.app-images.yaml
+++ b/helm-chart/templates/pvc.app-images.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.existingPVCs.appImages }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,4 +10,3 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.app }}
-{{- end }}

--- a/helm-chart/templates/pvc.mongo-data.yaml
+++ b/helm-chart/templates/pvc.mongo-data.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.existingPVCs.mongoData }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,4 +10,3 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.db }}
-{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -9,7 +9,7 @@ app:
     repository: ghcr.io/codeforphilly/pa-wildflower-selector/app
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.3"
+    tag: "2.0.4"
   env:
     - name: NODE_OPTIONS
       value: "--openssl-legacy-provider --max-old-space-size=768"


### PR DESCRIPTION
This pull request updates the Helm chart for the application to align with the new application version `2.0.4` and simplifies the configuration by removing conditional logic for existing Persistent Volume Claims (PVCs). Below are the key changes grouped by theme:

### Version Updates:
* Updated `version` and `appVersion` in `helm-chart/Chart.yaml` to `2.0.4` to reflect the new application version.
* Updated the image `tag` in `helm-chart/values.yaml` to `2.0.4` to match the new application version.

### Simplification of PVC Configuration:
* Removed conditional logic for `existingPVCs` in `helm-chart/templates/deployment.yaml` by directly setting `claimName` for `app-images` and `mongo-data` volumes.
* Deleted conditional blocks for `existingPVCs` in `helm-chart/templates/pvc.app-images.yaml` and `helm-chart/templates/pvc.mongo-data.yaml`, simplifying the PVC definitions. [[1]](diffhunk://#diff-beeae246fcae87b8e96d268330a1a25202944d21990f6aa2f850e2b059974a1dL1) [[2]](diffhunk://#diff-6058d9a02231cb94f4056686d7ef6f854d2c85b102b7921041a5bed2a53a5bccL1)
* Removed `end` statements associated with the deleted conditional logic in the PVC `spec` sections. [[1]](diffhunk://#diff-beeae246fcae87b8e96d268330a1a25202944d21990f6aa2f850e2b059974a1dL14) [[2]](diffhunk://#diff-6058d9a02231cb94f4056686d7ef6f854d2c85b102b7921041a5bed2a53a5bccL14)