### PR TITLE
added italics tag to the scientific name h1 tag in explorer.vue

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -43,7 +43,7 @@
         <div class="two-up-text">
           <h1>{{ selected['Common Name'] }}<button @click="toggleFavorite(selected._id)" class="favorite-selected text"><span class="material-icons material-align">{{ renderFavorite(selected._id) }}</span></button>
 </h1>
-          <h2>{{ selected['Scientific Name'] }}</h2>
+          <h2><i>{{ selected['Scientific Name'] }}</i></h2>
           <p v-if="selected['Blurb']">{{ selected['Blurb'] }}</p>
           <p v-if="selected['Flowering Months']">
             Flowering Months:


### PR DESCRIPTION
Chicago Manual of Style and APA Style
Both advocate italicizing Latin binomials for plants and animals.

MLA Handbook (for scientific writing)
Follows the same rule: scientific names in Latin (genus/species) should be italicized.

This pull request includes a minor update to the `Explorer.vue` component to improve the visual presentation of the scientific name of the selected item.

* In `src/components/Explorer.vue`, the scientific name (`selected['Scientific Name']`) is now displayed in italics by wrapping it with `<i>` tags.