### PR TITLE
Update branding from PA to USA nationwide

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -22,7 +22,7 @@
             <router-link to="/how-to-use">How to Use</router-link>
             <router-link to="/map">Nurseries</router-link>
           </span>
-          <div class="copyright">© 2025 Choose Native Plants - PA</div>
+          <div class="copyright">© 2025 Choose Native Plants - USA</div>
         </menu>
       </div>
       <slot name="before-bar"></slot>

--- a/src/components/HowToUsePage.vue
+++ b/src/components/HowToUsePage.vue
@@ -247,7 +247,7 @@
         or cookies are used. By using these features you consent to the collection
         of this information.
       </p>
-      <p>© 2025 Choose Native Plants - PA</p>
+      <p>© 2025 Choose Native Plants - USA</p>
     </article>
     <Up />
     <div class="tone">


### PR DESCRIPTION
This pull request updates the copyright information across the application to reflect a broader geographical scope, changing "PA" to "USA."

Copyright updates:

* [`src/components/Header.vue`](diffhunk://#diff-c970699f851dadc4a40a1c2a7b29886d5da454125e84e387a8d0abfa8b63be85L25-R25): Updated the copyright text in the header from "© 2025 Choose Native Plants - PA" to "© 2025 Choose Native Plants - USA."
* [`src/components/HowToUsePage.vue`](diffhunk://#diff-919225fdac5a6b46882d4fa3fd9c80bc07e1544822a53c2da14cf0c8c6749a68L250-R250): Updated the copyright text on the "How to Use" page from "© 2025 Choose Native Plants - PA" to "© 2025 Choose Native Plants - USA."