### PR TITLE
Update Helm chart for 2.0.5 release

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.4
+version: 2.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.0.4
+appVersion: 2.0.5

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -9,7 +9,7 @@ app:
     repository: ghcr.io/codeforphilly/pa-wildflower-selector/app
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.4"
+    tag: "2.0.5"
   env:
     - name: NODE_OPTIONS
       value: "--openssl-legacy-provider --max-old-space-size=768"


### PR DESCRIPTION
This pull request updates the version of the application and its associated Docker image tag in the Helm chart configuration files to reflect the new release version `2.0.5`. 

Version updates:

* [`helm-chart/Chart.yaml`](diffhunk://#diff-a798e6ac6aa43db0bdfec21d4fe9d2a5f9cc9a70079ac1491f5accddf16a1a73L18-R23): Updated the `version` and `appVersion` fields from `2.0.4` to `2.0.5` to align with the new application release.
* [`helm-chart/values.yaml`](diffhunk://#diff-15210b6a69967e9488632bf12df699fc922b886f3b38d79fdef46502d8bdbd30L12-R12): Updated the Docker image `tag` from `2.0.4` to `2.0.5` to ensure the correct image is deployed.