### PR TITLE
Add query rule search

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,27 @@ const version = fs.existsSync(versionFile)
   ? fs.readFileSync(versionFile, "utf8")
   : "0";
 const axios = require("axios");
+const ini = require("ini");
+
+// Load query rules from queryrules.ini at startup
+const queryRulesPath = path.join(__dirname, "queryrules.ini");
+let queryRules = {};
+if (fs.existsSync(queryRulesPath)) {
+  const parsed = ini.parse(fs.readFileSync(queryRulesPath, "utf8"));
+  for (const [name, rule] of Object.entries(parsed)) {
+    try {
+      queryRules[name] = {
+        chip: rule.Chip,
+        keywords: String(rule.Keywords || "")
+          .split(/,\s*/)
+          .filter(Boolean),
+        query: JSON.parse(rule.Query),
+      };
+    } catch (e) {
+      console.error(`Failed to parse query rule ${name}:`, e);
+    }
+  }
+}
 
 // Disabled for now because it causes confusion when we update the data
 // const cache = {};
@@ -59,11 +80,31 @@ module.exports = async function ({ plants, nurseries }) {
     });
     return res.send(response.data);
   });
+
+  // Provide query rules to the frontend
+  app.get("/api/v1/queryrules", (req, res) => {
+    res.json(queryRules);
+  });
   app.get("/api/v1/plants", async (req, res) => {
     try {
       const fetchResults = req.query.results !== "0";
       const fetchTotal = req.query.total !== "0";
       const query = {};
+      const ruleChips = [];
+      const rulesParam = req.query.rules;
+      if (rulesParam) {
+        const names = Array.isArray(rulesParam)
+          ? rulesParam
+          : String(rulesParam).split(/,/);
+        for (const name of names) {
+          const rule = queryRules[name];
+          if (rule) {
+            if (!query.$and) query.$and = [];
+            query.$and.push(rule.query);
+            ruleChips.push({ name, chip: rule.chip });
+          }
+        }
+      }
       const sorts = {
         "Sort by Common Name (A-Z)": {
           "Common Name": 1,
@@ -436,6 +477,9 @@ module.exports = async function ({ plants, nurseries }) {
             )
           );
         }
+      }
+      if (ruleChips.length) {
+        response.ruleChips = ruleChips;
       }
       // setCache(req, response);
       return res.send(response);


### PR DESCRIPTION
## Summary
- load `queryrules.ini` on server startup
- expose query rules via `/api/v1/queryrules`
- apply rule filters in `/api/v1/plants` when `rules` param provided
- show rule chips and search behavior on the client
- parse search keywords client-side to activate rule-based filtering

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*