### PR TITLE
fix(helm): increase liveness probe timeout and failure threshold

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.1.5
+appVersion: 2.2.8

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -211,9 +211,9 @@ spec:
               path: /
               port: http
             initialDelaySeconds: 60
-            timeoutSeconds: 10
+            timeoutSeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 5
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
## Summary

- `timeoutSeconds`: 10 → 30
- `failureThreshold`: 3 → 5
- Chart version: 2.0.7 → 2.0.8
- `appVersion` corrected to 2.2.8 (was stale at 2.1.5)

## Background

The app loads ML embeddings for ~5,800 plants at startup and can experience GC pauses under load — particularly when bot scanners probe for `.env`, `.git/config`, and similar files (visible in logs as bursts of Vue Router 404 warnings). The original 10s liveness probe timeout is too tight for these conditions; the kubelet kills the container after 3 consecutive failures even though the app is fundamentally healthy.

This is the second part of a two-part fix alongside a memory increase in cfp-live-cluster. Once this PR is merged and tagged (e.g. `v2.2.9`), both `cfp-sandbox-cluster` and `cfp-live-cluster` holo sources should be updated from `refs/tags/v2.2.8` to the new tag to pick up this chart change.

## Test plan

- [ ] Merge and cut a new release tag (e.g. `v2.2.9`)
- [ ] Update `.holo/sources/choose-native-plants.toml` in cfp-sandbox-cluster and cfp-live-cluster to the new tag
- [ ] Confirm sandbox pod no longer restarts during bot scanner traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)