### PR TITLE
fix: prevent SSR prefetch failures from crashing the process

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1519,7 +1519,12 @@ module.exports = async function ({ plants, nurseries }) {
     }
 
     // Production mode with SSR
-    const appContent = await renderer({ port, url: req.url });
+    let appContent = "";
+    try {
+      appContent = await renderer({ port, url: req.url });
+    } catch (error) {
+      console.error("SSR render failed; serving empty shell for client hydration:", error);
+    }
     const cssLink = manifest["app.css"] ? `<link rel="stylesheet" href="${manifest["app.css"]}?version=${version}" />` : "";
     const html = `
     <!DOCTYPE html>

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -1311,11 +1311,15 @@ export default {
   },
   // Server only
   async serverPrefetch() {
-    await this.determineFilterCounts();
-    this.page = 1;
-    this.loadedAll = false;
-    this.total = 0;
-    await this.fetchPage(true);
+    try {
+      await this.determineFilterCounts();
+      this.page = 1;
+      this.loadedAll = false;
+      this.total = 0;
+      await this.fetchPage(true);
+    } catch (error) {
+      console.error("SSR prefetch failed; client will hydrate:", error);
+    }
   },
   async postData(url = "", data = {}) {
     // Default options are marked with *
@@ -2612,6 +2616,7 @@ export default {
     },
     async determineFilterCounts() {
       this.initializing = true;
+      try {
       if (!this.determinedFilterCounts) {
         const response = await fetch("/api/v1/plants?results=0&total=0");
         const data = await response.json();
@@ -2670,7 +2675,11 @@ export default {
         }
         this.determinedFilterCounts = true;
       }
-      this.initializing = false;
+      } catch (error) {
+        console.error("Failed to load filter counts:", error);
+      } finally {
+        this.initializing = false;
+      }
     },
     imageUrl(result, preview) {
       if (!result || !result._id) return "/assets/images/missing-image.png";

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -41,8 +41,12 @@ export default {
   },
   // Server only
   async serverPrefetch() {
-    this.server = true;
-    await this.fetchNurseries();
+    try {
+      this.server = true;
+      await this.fetchNurseries();
+    } catch (error) {
+      console.error("SSR prefetch failed; client will hydrate:", error);
+    }
   },
   // Browser only
   async mounted() {


### PR DESCRIPTION
## Summary
- Wrap `serverPrefetch` in Explorer and Map with try/catch so failed upstream API calls during SSR no longer throw uncaught rejections.
- Wrap `determineFilterCounts` in Explorer with try/catch/finally so loading state still clears on failure.
- Wrap the production SSR `renderer` call in `lib/server.js` so render errors log and serve an empty `#app` shell for client hydration.

## Context
On June 13 the app process crashed during SSR when prefetch hit a transient **ECONNRESET** (upstream connection reset). That error propagated as an unhandled rejection and took down the Node process / Kubernetes pod.

## Behavior after this change
SSR prefetch and render failures are logged and the response degrades gracefully: the HTML shell still loads and the client hydrates and refetches data in the browser instead of crashing the server.

## Test plan
- [ ] Deploy or run production SSR build and confirm pages still render when APIs are healthy.
- [ ] Simulate upstream failure during SSR prefetch and confirm the pod stays up and the page hydrates on the client.

Made with [Cursor](https://cursor.com)