### PR TITLE
fix: add /healthz liveness probe endpoint

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -208,7 +208,7 @@ spec:
               subPath: app-images
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 30

--- a/lib/server.js
+++ b/lib/server.js
@@ -79,6 +79,8 @@ module.exports = async function ({ plants, nurseries }) {
     app.use("/images", express.static(imagesDir));
   }
 
+  app.get("/healthz", (req, res) => res.status(200).send("ok"));
+
   // Resolve plant image based on the requested mode, with graceful fallback.
   // This avoids client-side 404 handling for background images and centralizes
   // the mapping between habitat (images/) and studio (images/studio_full/).


### PR DESCRIPTION
## Summary
- Add `GET /healthz` on the Express app (after static middleware, before API routes) returning `200` with body `ok`.
- Point the Helm chart liveness probe at `/healthz` instead of `/`.

## Why
Liveness checks against `/` trigger the SSR catch-all and full page render work on every probe interval. A dedicated health endpoint keeps probes cheap and reliable.

## Test plan
- [ ] `curl -i http://localhost:3000/healthz` returns 200 and `ok`.
- [ ] After deploy, confirm pods stay healthy and liveness no longer hits SSR for `/`.

Made with [Cursor](https://cursor.com)