### PR TITLE
fix: return 404 for common bot scanner probe paths

### DIFF
--- a/lib/scanner-probe-paths.js
+++ b/lib/scanner-probe-paths.js
@@ -1,0 +1,70 @@
+const path = require("path");
+
+const EXACT_PROBE_PATHS = new Set([
+  "/.env",
+  "/.env.local",
+  "/.env.production",
+  "/.git/config",
+  "/wp-login.php",
+  "/xmlrpc.php",
+]);
+
+const PREFIX_PROBE_PATHS = [
+  "/.git/",
+  "/wp-admin",
+  "/wp-content",
+  "/wp-includes",
+  "/phpmyadmin",
+  "/phpMyAdmin",
+  "/pma/",
+  "/administrator",
+  "/.aws/",
+  "/actuator",
+  "/vendor/phpunit",
+  "/cgi-bin/",
+  "/.vscode/",
+  "/server-status",
+];
+
+const SCRIPT_PROBE_EXTENSIONS = /\.(php|asp|aspx|jsp|cgi)$/i;
+
+function normalizePathname(pathname) {
+  if (!pathname || typeof pathname !== "string") {
+    return "";
+  }
+  const withoutQuery = pathname.split("?")[0];
+  const normalized = path.posix.normalize(withoutQuery);
+  if (normalized === "." || normalized === "/") {
+    return "/";
+  }
+  return normalized.startsWith("/") ? normalized : `/${normalized}`;
+}
+
+function isScannerProbePath(pathname) {
+  const normalized = normalizePathname(pathname);
+  if (!normalized || normalized === "/") {
+    return false;
+  }
+
+  if (EXACT_PROBE_PATHS.has(normalized)) {
+    return true;
+  }
+
+  const lower = normalized.toLowerCase();
+
+  if (PREFIX_PROBE_PATHS.some((prefix) => lower.startsWith(prefix.toLowerCase()))) {
+    return true;
+  }
+
+  if (lower.includes("/.env") || lower.includes("/.git")) {
+    return true;
+  }
+
+  if (SCRIPT_PROBE_EXTENSIONS.test(lower)) {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = { isScannerProbePath };

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ const quote = require("regexp-quote");
 const path = require("path");
 const { generateEmbedding, cosineSimilarity } = require("./embeddings");
 const { parseNaturalLanguageQuery } = require("./keyword-mappings");
+const { isScannerProbePath } = require("./scanner-probe-paths");
 
 // Check if SSR build exists (production/Docker mode) or if we're in dev mode
 const isDevelopment = process.env.NODE_ENV === "development" || !fs.existsSync(path.join(__dirname, "../ssr/ssr-manifest.json"));
@@ -1487,6 +1488,15 @@ module.exports = async function ({ plants, nurseries }) {
         "EMAIL": x.publicEmail
        }
     })});
+  });
+  app.use((req, res, next) => {
+    if (
+      (req.method === "GET" || req.method === "HEAD") &&
+      isScannerProbePath(req.path)
+    ) {
+      return res.status(404).send("Not Found");
+    }
+    next();
   });
   app.get("*", async (req, res) => {
     // In development mode without SSR, serve a simple HTML that Vue dev server will handle


### PR DESCRIPTION
## Summary
- Add `lib/scanner-probe-paths.js` with `isScannerProbePath(pathname)` for common internet scanner targets (`.env`, `.git`, WordPress/PHP admin paths, etc.).
- Add Express middleware immediately before the SSR `app.get('*')` handler to return **404** for **GET** and **HEAD** requests on those paths.

## Why
Automated scanners hit typical CMS/PHP misconfiguration URLs. Our SPA catch-all was treating them like real page loads, adding log noise and unnecessary SSR work.

## Test plan
- [ ] `curl -i http://localhost:3000/.env` returns 404 without SSR.
- [ ] `curl -i http://localhost:3000/api/v1/plants` still works.
- [ ] Normal app routes still render via SSR/client as before.

Made with [Cursor](https://cursor.com)