### PR TITLE
Remove planner overlap warning visuals

### DIFF
--- a/src/components/GardenCanvas.vue
+++ b/src/components/GardenCanvas.vue
@@ -28,7 +28,6 @@
           :key="p.id"
           :placed="p"
           :plant="plantById[p.plantId]"
-          :is-overlapping="overlapIds.has(p.id)"
           :is-dragging="dragState.isDragging && dragState.plantId === p.id && dragState.dragType === 'move'"
           :is-selected="selectedPlacedPlantId === p.id"
           :show-label="labelModeResolved === 'all'"
@@ -76,13 +75,6 @@
           </div>
         </div>
 
-        <!-- Overlap warning - positioned on canvas -->
-        <div 
-          v-if="placedPlants.length && overlapIds.size"
-          class="overlap-hint"
-        >
-          Some plants overlap (crowding risk)
-        </div>
       </div>
 
       <!-- Top Controls -->
@@ -184,7 +176,6 @@ import type { PlacedPlant, Plant, GridCoords } from '../types/garden';
 interface Props {
   placedPlants: PlacedPlant[];
   plantById: Record<string, Plant>;
-  overlapIds: Set<string>;
   selectedPlantId: string | null;
   selectedPlacedPlantId: string | null;
   isMobile: boolean;
@@ -771,24 +762,6 @@ const gridHighlightStyle = computed(() => {
     );
   background-position: 0 0;
   touch-action: none;
-}
-
-.overlap-hint {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(200, 40, 40, 0.4);
-  border-left: 3px solid rgba(200, 40, 40, 0.85);
-  border-radius: 4px;
-  padding: 6px 10px;
-  font-family: Roboto;
-  font-size: 12px;
-  color: #6b1b1b;
-  z-index: 10;
-  pointer-events: none;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
 }
 
 button.primary-bar.small.danger {

--- a/src/components/GardenPlanner.vue
+++ b/src/components/GardenPlanner.vue
@@ -83,7 +83,6 @@
             ref="canvasRef"
             :placed-plants="placedPlants"
             :plant-by-id="plantById"
-            :overlap-ids="overlapIds"
             :selected-plant-id="selectedPlantId"
             :selected-placed-plant-id="selectedPlacedPlantId"
             :is-mobile="isMobile"
@@ -204,7 +203,6 @@ const {
   selectedPlantId,
   selectedPlacedPlantId,
   plantById,
-  overlapIds,
   plantCounts,
   imageUrl,
   spreadFeetLabel,

--- a/src/components/PlantCircle.vue
+++ b/src/components/PlantCircle.vue
@@ -3,7 +3,6 @@
     ref="plantRef"
     class="placed"
     :class="{
-      overlapping: isOverlapping,
       dragging: isDragging,
       selected: isSelected
     }"
@@ -68,7 +67,6 @@ interface Emits {
 interface Props {
   placed: PlacedPlant;
   plant: Plant | undefined;
-  isOverlapping: boolean;
   isDragging?: boolean;
   isSelected?: boolean;
   showLabel?: boolean;
@@ -333,12 +331,6 @@ const handleDeleteClick = () => {
   touch-action: none;
 }
 
-.placed.overlapping {
-  border-color: rgba(220, 30, 30, 1);
-  border-style: dashed;
-  animation: pulseOverlap 1.75s ease-in-out infinite;
-}
-
 .placed.dragging {
   opacity: 0.4;
   pointer-events: none;
@@ -422,17 +414,6 @@ const handleDeleteClick = () => {
   border: 1px solid rgba(255, 255, 255, 0.3);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
   margin-bottom: 4px;
-}
-
-@keyframes pulseOverlap {
-  0%, 100% {
-    border-width: 2px;
-    box-shadow: 0 0 0 2px rgba(220, 30, 30, 0.3);
-  }
-  50% {
-    border-width: 6px;
-    box-shadow: 0 0 0 5px rgba(220, 30, 30, 0.5);
-  }
 }
 
 .plant-actions {
@@ -525,4 +506,3 @@ const handleDeleteClick = () => {
   }
 }
 </style>
-

--- a/src/composables/useGardenPlanner.ts
+++ b/src/composables/useGardenPlanner.ts
@@ -64,22 +64,6 @@ export function useGardenPlanner() {
     return map;
   });
 
-  const overlapIds = computed(() => {
-    const overlaps = new Set<string>();
-    const items = placedPlants.value;
-    for (let i = 0; i < items.length; i++) {
-      const a = items[i];
-      for (let j = i + 1; j < items.length; j++) {
-        const b = items[j];
-        if (circlesOverlap(a, b)) {
-          overlaps.add(a.id);
-          overlaps.add(b.id);
-        }
-      }
-    }
-    return overlaps;
-  });
-
   const plantCounts = computed(() => {
     const counts: Record<string, number> = {};
     for (const p of placedPlants.value) {
@@ -689,7 +673,6 @@ export function useGardenPlanner() {
     // Computed
     favoriteIds,
     plantById,
-    overlapIds,
     plantCounts,
 
     // Methods
@@ -801,4 +784,3 @@ export function useGardenPlanner() {
     importDesignFromText,
   };
 }
-


### PR DESCRIPTION
## Summary
- remove the red overlap pulse/dashed styling from placed plants
- remove the overlap risk note from the garden canvas
- trim unused overlap warning prop/computed plumbing

## Testing
- Not run: local build requires node_modules/vue-cli-service, which is not installed in this checkout