### PR TITLE
feat: add browse result states and remove garden overlap UI

### DIFF
--- a/src/components/BrowseResultStates.vue
+++ b/src/components/BrowseResultStates.vue
@@ -1,0 +1,349 @@
+<template>
+  <div class="browse-result-states">
+    <!-- Initial / full refresh loading -->
+    <div
+      v-if="state === 'loading'"
+      class="browse-state browse-state--loading"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <p class="browse-state-message">{{ message }}</p>
+      <div class="browse-skeleton-grid" aria-hidden="true">
+        <article
+          v-for="index in skeletonCount"
+          :key="index"
+          class="browse-skeleton-card"
+        >
+          <div
+            class="browse-skeleton-photo"
+            :class="{
+              'browse-skeleton-photo--studio': photoMode === 'studio',
+            }"
+          ></div>
+          <div
+            v-if="photoMode === 'studio'"
+            class="browse-skeleton-caption"
+          >
+            <div class="browse-skeleton-line browse-skeleton-line--title"></div>
+            <div class="browse-skeleton-line browse-skeleton-line--subtitle"></div>
+          </div>
+        </article>
+      </div>
+    </div>
+
+    <!-- Zero matches -->
+    <div
+      v-else-if="state === 'no-results'"
+      class="browse-state browse-state--no-results"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="browse-state-icon" aria-hidden="true">
+        <span class="material-icons">search_off</span>
+      </div>
+      <h2 class="browse-state-heading">{{ noResultsHeading }}</h2>
+      <p class="browse-state-body">{{ noResultsBody }}</p>
+      <div v-if="hasActions" class="browse-state-actions">
+        <button
+          v-if="activeFilterCount > 0"
+          type="button"
+          class="primary"
+          @click="$emit('clear-filters')"
+        >
+          Remove filters
+        </button>
+        <button
+          v-else-if="hasPlantSearch"
+          type="button"
+          class="primary"
+          @click="$emit('clear-search')"
+        >
+          Clear search
+        </button>
+        <button
+          v-if="!nearDisplayLabel"
+          type="button"
+          class="secondary"
+          @click="$emit('set-location')"
+        >
+          Set location
+        </button>
+      </div>
+    </div>
+
+    <!-- Fetch error -->
+    <div
+      v-else-if="state === 'error'"
+      class="browse-state browse-state--error"
+      role="alert"
+    >
+      <div class="browse-state-icon browse-state-icon--error" aria-hidden="true">
+        <span class="material-icons">error_outline</span>
+      </div>
+      <h2 class="browse-state-heading">Could not load plants</h2>
+      <p class="browse-state-body">{{ message }}</p>
+      <div class="browse-state-actions">
+        <button type="button" class="primary" @click="$emit('retry')">
+          Try again
+        </button>
+      </div>
+    </div>
+
+    <!-- Pagination / filter refresh while results remain visible -->
+    <div
+      v-else-if="state === 'updating'"
+      class="browse-updating"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span class="browse-updating-spinner" aria-hidden="true"></span>
+      <span>Updating results…</span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "BrowseResultStates",
+  props: {
+    state: {
+      type: String,
+      required: true,
+      validator: (value) =>
+        ["loading", "no-results", "error", "updating"].includes(value),
+    },
+    message: {
+      type: String,
+      default: "Loading native plants…",
+    },
+    nearDisplayLabel: {
+      type: String,
+      default: "",
+    },
+    activeFilterCount: {
+      type: Number,
+      default: 0,
+    },
+    hasPlantSearch: {
+      type: Boolean,
+      default: false,
+    },
+    photoMode: {
+      type: String,
+      default: "habitat",
+    },
+    skeletonCount: {
+      type: Number,
+      default: 6,
+    },
+  },
+  emits: ["clear-filters", "clear-search", "set-location", "retry"],
+  computed: {
+    noResultsHeading() {
+      const near = (this.nearDisplayLabel || "").trim();
+      if (near) {
+        return `No plants match near ${near}`;
+      }
+      return "No plants match this search";
+    },
+    noResultsBody() {
+      if (this.activeFilterCount > 0) {
+        return "Try removing filters to see more native plants.";
+      }
+      if (this.hasPlantSearch) {
+        return "Try broadening your search or checking the spelling.";
+      }
+      return "Try removing filters or broadening your search.";
+    },
+    hasActions() {
+      return (
+        this.activeFilterCount > 0 ||
+        this.hasPlantSearch ||
+        !this.nearDisplayLabel
+      );
+    },
+  },
+};
+</script>
+
+<style scoped>
+.browse-result-states {
+  width: 100%;
+}
+
+.browse-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 32px 16px 40px;
+}
+
+.browse-state--loading {
+  align-items: stretch;
+  padding-top: 12px;
+}
+
+.browse-state-message {
+  margin: 0 0 16px;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.62);
+  text-align: center;
+}
+
+.browse-state-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: rgba(183, 77, 21, 0.1);
+  color: #b74d15;
+  margin-bottom: 16px;
+}
+
+.browse-state-icon--error {
+  background: rgba(180, 35, 24, 0.1);
+  color: #b42318;
+}
+
+.browse-state-icon .material-icons {
+  font-size: 28px;
+}
+
+.browse-state-heading {
+  margin: 0 0 8px;
+  font-family: Arvo, serif;
+  font-size: 20px;
+  font-weight: 400;
+  color: #1d2e26;
+  max-width: 28rem;
+}
+
+.browse-state-body {
+  margin: 0;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(0, 0, 0, 0.68);
+  max-width: 24rem;
+}
+
+.browse-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.browse-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(248px, 1fr));
+  gap: 8px;
+  width: 100%;
+}
+
+.browse-skeleton-card {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.browse-skeleton-photo {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.06) 0%,
+    rgba(0, 0, 0, 0.1) 50%,
+    rgba(0, 0, 0, 0.06) 100%
+  );
+  background-size: 200% 100%;
+  animation: browse-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.browse-skeleton-caption {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.browse-skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.06) 0%,
+    rgba(0, 0, 0, 0.1) 50%,
+    rgba(0, 0, 0, 0.06) 100%
+  );
+  background-size: 200% 100%;
+  animation: browse-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.browse-skeleton-line--title {
+  width: 72%;
+}
+
+.browse-skeleton-line--subtitle {
+  width: 52%;
+}
+
+.browse-updating {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px 0 8px;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.62);
+}
+
+.browse-updating-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(183, 77, 21, 0.2);
+  border-top-color: #b74d15;
+  border-radius: 50%;
+  animation: browse-spin 0.8s linear infinite;
+}
+
+@keyframes browse-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes browse-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .browse-skeleton-photo,
+  .browse-skeleton-line,
+  .browse-updating-spinner {
+    animation: none;
+  }
+}
+
+@media all and (max-width: 480px) {
+  .browse-skeleton-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+</style>

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -655,7 +655,39 @@
               </div>
             </section>
           </template>
-          <article v-else class="plants">
+          <BrowseResultStates
+            v-else-if="showBrowseLoading"
+            state="loading"
+            :message="browseLoadingMessage"
+            :photo-mode="photoMode"
+          />
+          <BrowseResultStates
+            v-else-if="showBrowseError"
+            state="error"
+            :message="fetchError"
+            @retry="retryBrowseFetch"
+          />
+          <BrowseResultStates
+            v-else-if="showBrowseNoResults"
+            state="no-results"
+            :near-display-label="nearDisplayLabel"
+            :active-filter-count="activeFilterCount"
+            :has-plant-search="hasSearchChip"
+            @clear-filters="clearAll"
+            @clear-search="clearSearchOnly"
+            @set-location="setLocation"
+          />
+          <div v-else class="browse-results">
+            <p
+              v-if="!favorites && total > 0"
+              class="browse-result-count"
+              role="status"
+              aria-live="polite"
+            >
+              Showing {{ results.length }} of {{ total }} plants
+              <span v-if="nearDisplayLabel"> near {{ nearDisplayLabel }}</span>
+            </p>
+            <article class="plants">
             <article
               v-for="result in results"
               :key="result._id"
@@ -726,7 +758,12 @@
             <!-- Infinite scroll sentinel: keep it anchored to the *results* column,
                  not after <main> (desktop filters column can add large bottom space). -->
             <div ref="next" class="infinite-scroll-sentinel" aria-hidden="true"></div>
+            <BrowseResultStates
+              v-if="showBrowseUpdating"
+              state="updating"
+            />
           </article>
+          </div>
         </div>
     </main>
     <BulkAddFavoritesModal
@@ -751,6 +788,7 @@ import Checkbox from "./Checkbox.vue";
 import Header from "./Header.vue";
 import Menu from "./Menu.vue";
 import BulkAddFavoritesModal from "./BulkAddFavoritesModal.vue";
+import BrowseResultStates from "./BrowseResultStates.vue";
 import { Trash2 } from "lucide-vue-next";
 
 const twoUpImageCredits = [
@@ -794,6 +832,7 @@ export default {
     Header,
     Menu,
     BulkAddFavoritesModal,
+    BrowseResultStates,
     Trash2,
   },
   props: {
@@ -983,6 +1022,7 @@ export default {
       total: 0,
       page: 1,
       loading: false,
+      fetchError: null,
       loadedAll: false,
       checkingLoadMore: false, // Guard flag to prevent concurrent "load next page" calls
       fetchRequestId: 0,
@@ -1181,6 +1221,63 @@ export default {
     },
     quickAddPlants() {
       return Array.isArray(this.quickAddResults) ? this.quickAddResults : [];
+    },
+    nearDisplayLabel() {
+      const zip = (this.zipCode || "").trim();
+      const location = (this.displayLocation || "").trim();
+      if (location && zip) {
+        return `${location} · ${zip}`;
+      }
+      if (location) {
+        return location;
+      }
+      if (zip) {
+        return zip;
+      }
+      return "";
+    },
+    activeFilterCount() {
+      return this.chips.filter((chip) => chip.name !== "Search").length;
+    },
+    browseLoadingMessage() {
+      if (this.isLoadingLocation && !this.manualZip) {
+        return "Finding plants near you…";
+      }
+      return "Loading native plants…";
+    },
+    showBrowseLoading() {
+      if (this.fetchError || !this.loading || this.results.length > 0) {
+        return false;
+      }
+      if (this.favorites) {
+        return this.favoritesCount > 0;
+      }
+      return true;
+    },
+    showBrowseError() {
+      if (!this.fetchError || this.results.length > 0) {
+        return false;
+      }
+      if (this.favorites) {
+        return this.favoritesCount > 0;
+      }
+      return true;
+    },
+    showBrowseNoResults() {
+      if (
+        this.loading ||
+        this.fetchError ||
+        this.results.length > 0
+      ) {
+        return false;
+      }
+      if (this.favorites) {
+        return false;
+      }
+      return this.total === 0;
+    },
+    showBrowseUpdating() {
+      return this.loading && this.results.length > 0;
     },
   },
   watch: {
@@ -2945,6 +3042,7 @@ export default {
         this.page = 1; // Start at page 1 (server expects >= 1)
         this.loadedAll = false;
         this.total = 0; // Reset total as well
+        this.fetchError = null;
         this.checkingLoadMore = false;
 
         // Fetch new data and replace results when it arrives
@@ -3051,12 +3149,17 @@ export default {
         const response = await fetch(
           "/api/v1/plants?" + qs.stringify(cleanedParams, { arrayFormat: "repeat" })
         );
+        if (!response.ok) {
+          throw new Error(`Could not load plants (${response.status})`);
+        }
         const data = await response.json();
 
         // Ignore stale responses (e.g., filter/sort changed mid-flight).
         if (this.activeFetchRequestId !== requestId) {
           return;
         }
+
+        this.fetchError = null;
 
         if (!this.favorites) {
           this.filterCounts = data.counts;
@@ -3241,6 +3344,9 @@ export default {
       } catch (error) {
         if (this.activeFetchRequestId === requestId) {
           console.error("Error fetching plants:", error);
+          this.fetchError =
+            (error && error.message) ||
+            "Could not load plants. Please try again.";
         }
       } finally {
         if (this.activeFetchRequestId === requestId) {
@@ -3490,58 +3596,57 @@ export default {
     },
     removeChip(chip) {
       if (chip.name === "Search") {
-        // When removing search chip: clear activeSearch but keep all filter chips
-        this.q = "";
-        this.activeSearch = "";
-        this.hasExtractedFilters = false;
-        // Close sort dropdown if it's open
-        if (this.sortIsOpen) {
-          this.sortIsOpen = false;
-        }
-        // Filter chips remain intact in filterValues
-        this.submit();
-      } else {
-        // When removing filter chip: only update filterValues, preserve activeSearch
-        const filter = this.filters.find((filter) => filter.name === chip.name);
-        if (filter && filter.array) {
-          // Create a new array to ensure Vue reactivity detects the change
-          const currentValues = this.filterValues[chip.name] || [];
-          this.filterValues[chip.name] = currentValues.filter(
-            (value) => value !== chip.label
-          );
-        } else if (filter && filter.range) {
-          // For range filters, set to match the current filter bounds (full range)
-          // This ensures the filter is not active after removing the chip
-          this.filterValues[chip.name] = {
-            min: filter.min,
-            max: filter.max
-          };
-        } else if (filter) {
-          this.filterValues[chip.name] = filter.default;
-        }
-        
-        // Don't clear activeSearch when removing filter chips
-        // This allows semantic search to continue working with remaining filters
-        
-        // If activeSearch is empty or doesn't have meaningful content, and we're sorting by Search Relevance,
-        // switch back to the previous sort to ensure proper sorting when filters are removed
-        if ((!this.activeSearch || !this.activeSearch.trim() || !this.getRemainingQueryText(this.activeSearch).trim()) && 
-            this.sort === "Sort by Search Relevance") {
-          if (this.previousSort) {
-            this.sort = this.previousSort;
-          } else {
-            // Fallback to default sort if previousSort is not set
-            this.sort = "Sort by Recommendation Score";
-          }
-        }
-        
-        // The filterValues watcher will trigger, but ensure submit happens
-        // Use $nextTick to ensure the watcher has processed the change
-        this.$nextTick(() => {
-          // Force submit to ensure counts and results update
-          this.submit();
-        });
+        this.clearSearchOnly();
+        return;
       }
+
+      const filter = this.filters.find((filter) => filter.name === chip.name);
+      if (filter && filter.array) {
+        const currentValues = this.filterValues[chip.name] || [];
+        this.filterValues[chip.name] = currentValues.filter(
+          (value) => value !== chip.label
+        );
+      } else if (filter && filter.range) {
+        this.filterValues[chip.name] = {
+          min: filter.min,
+          max: filter.max
+        };
+      } else if (filter) {
+        this.filterValues[chip.name] = filter.default;
+      }
+
+      if ((!this.activeSearch || !this.activeSearch.trim() || !this.getRemainingQueryText(this.activeSearch).trim()) &&
+          this.sort === "Sort by Search Relevance") {
+        if (this.previousSort) {
+          this.sort = this.previousSort;
+        } else {
+          this.sort = "Sort by Recommendation Score";
+        }
+      }
+
+      this.$nextTick(() => {
+        this.submit();
+      });
+    },
+    clearSearchOnly() {
+      this.q = "";
+      this.activeSearch = "";
+      this.hasExtractedFilters = false;
+      if (this.sortIsOpen) {
+        this.sortIsOpen = false;
+      }
+      if (this.sort === "Sort by Search Relevance") {
+        if (this.previousSort) {
+          this.sort = this.previousSort;
+        } else {
+          this.sort = "Sort by Recommendation Score";
+        }
+      }
+      this.submit();
+    },
+    retryBrowseFetch() {
+      this.fetchError = null;
+      this.submit();
     },
     clearAll() {
       for (const filter of this.filters) {
@@ -5336,6 +5441,18 @@ th {
 
 .total-matches {
   text-align: center;
+}
+
+.browse-result-count {
+  margin: 0 0 12px;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.browse-results {
+  width: 100%;
 }
 
 


### PR DESCRIPTION
Add loading, error, empty, and updating states to the plant explorer, and drop overlap detection hints from the garden planner canvas.