### PR TITLE
feat: replace zip prompt with inline location search field

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -13,11 +13,15 @@
       <div v-if="!favorites" class="compact-utility-header">
         <div class="utility-content">
           <div class="location-section">
-            <button class="location-btn" @click="setLocation()">
-              <span class="material-icons">place</span>
-              <span v-if="zipCode">Change Location [{{ zipCode }}]</span>
-              <span v-else>Set Location</span>
-            </button>
+            <LocationSearchField
+              ref="locationBar"
+              variant="bar"
+              :applied-zip="zipCode"
+              :applied-display-location="displayLocation"
+              :commit-handler="commitLocationZip"
+              :external-loading="isLoadingLocation"
+              @cleared="clearLocation"
+            />
           </div>
         </div>
       </div>
@@ -164,7 +168,11 @@
           <h3 v-if="localStoreLinks.length || onlineStoreLinks.length">
             Nurseries that carry this native plant:
           </h3>
-          <h4 class="enter-location" v-if="!this.zipCode"><a @click="setLocation()">Enter your location in order to see nearby stores</a></h4>
+          <h4 class="enter-location" v-if="!this.zipCode">
+            <button type="button" class="text enter-location-link" @click="focusLocationField">
+              Enter your location in order to see nearby stores
+            </button>
+          </h4>
           <h4 v-if="this.zipCode && localStoreLinks.length">Local Nurseries</h4>
           <p class="store-links">
             <a
@@ -353,15 +361,16 @@
             <div class="browse-toolbar" aria-label="Browse controls">
               <!-- Row 1: primary actions -->
               <div class="browse-toolbar-row browse-toolbar-row--actions">
-                <button
-                  type="button"
-                  class="browse-location-button"
-                  @click="setLocation()"
-                  :aria-label="zipCode ? `Change location (ZIP ${zipCode})` : 'Set location'"
-                  title="Change location"
-                >
-                  <span class="material-icons" aria-hidden="true">place</span>
-                </button>
+                <LocationSearchField
+                  ref="locationToolbar"
+                  class="browse-location-field"
+                  variant="toolbar"
+                  :applied-zip="zipCode"
+                  :applied-display-location="displayLocation"
+                  :commit-handler="commitLocationZip"
+                  :external-loading="isLoadingLocation"
+                  @cleared="clearLocation"
+                />
 
                 <button type="button" class="primary browse-filter-button" @click="openFilters">
                   <span class="material-icons" aria-hidden="true">tune</span>
@@ -462,6 +471,18 @@
               </button>
             </div>
             <div class="inner-controls">
+              <LocationSearchField
+                v-if="filtersOpen && !isDesktop()"
+                ref="locationDrawer"
+                class="filters-drawer-location"
+                variant="drawer"
+                show-label
+                :applied-zip="zipCode"
+                :applied-display-location="displayLocation"
+                :commit-handler="commitLocationZip"
+                :external-loading="isLoadingLocation"
+                @cleared="clearLocation"
+              />
               <div class="search-mobile-wrapper">
                 <div class="search-mobile-box">
                   <span class="material-icons">search</span>
@@ -675,7 +696,7 @@
             :has-plant-search="hasSearchChip"
             @clear-filters="clearAll"
             @clear-search="clearSearchOnly"
-            @set-location="setLocation"
+            @set-location="focusLocationField"
           />
           <div v-else class="browse-results">
             <p
@@ -789,6 +810,7 @@ import Header from "./Header.vue";
 import Menu from "./Menu.vue";
 import BulkAddFavoritesModal from "./BulkAddFavoritesModal.vue";
 import BrowseResultStates from "./BrowseResultStates.vue";
+import LocationSearchField from "./LocationSearchField.vue";
 import { Trash2 } from "lucide-vue-next";
 
 const twoUpImageCredits = [
@@ -833,6 +855,7 @@ export default {
     Menu,
     BulkAddFavoritesModal,
     BrowseResultStates,
+    LocationSearchField,
     Trash2,
   },
   props: {
@@ -1653,40 +1676,57 @@ export default {
         el.style.display = display;
       }
     },
-    async setLocation() {
-      this.zipCode = prompt("Please enter your zipcode");
-      if (!this.zipCode) return;
-      if (!/^\d{5}$/.test(this.zipCode)) {
-        alert("Zipcode must be 5 digits");
-        return;
+    async commitLocationZip(zip) {
+      const response = await fetch("/get-city", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ zipCode: zip }),
+      });
+      if (!response.ok) {
+        throw new Error("Could not find that ZIP code. Please try again.");
       }
-      try {
-        const response = await fetch("/get-city", {
-          method: "POST", // *GET, POST, PUT, DELETE, etc.
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ zipCode: this.zipCode }), // body data type must match "Content-Type" header
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+      const json = await response.json();
+      this.zipCode = zip;
+      this.filterValues["States"] = [json.state];
+      this.displayLocation = `${json.city}, ${json.state}`;
+      localStorage.setItem("displayLocation", this.displayLocation);
+      localStorage.setItem("zipCode", this.zipCode);
+      localStorage.setItem("state", json.state);
+      this.manualZip = true;
+      localStorage.setItem("manualZip", "true");
+
+      if (this.selected) {
+        this.getVendors();
+      }
+      this.submit();
+    },
+    clearLocation() {
+      this.zipCode = "";
+      this.displayLocation = "";
+      this.manualZip = false;
+      this.filterValues["States"] = this.defaultFilterValues["States"];
+      localStorage.removeItem("zipCode");
+      localStorage.removeItem("displayLocation");
+      localStorage.removeItem("manualZip");
+      localStorage.removeItem("state");
+      if (this.selected) {
+        this.localStoreLinks = [];
+      }
+      this.submit();
+    },
+    focusLocationField() {
+      const refs = [
+        this.$refs.locationBar,
+        this.$refs.locationToolbar,
+        this.$refs.locationDrawer,
+      ].filter(Boolean);
+      for (const field of refs) {
+        if (field && typeof field.focus === "function") {
+          field.focus();
+          return;
         }
-        let json = await response.json();
-        this.filterValues["States"] = [json.state];
-        this.displayLocation = `${json.city}, ${json.state}`;
-        localStorage.setItem("displayLocation", this.displayLocation)
-        localStorage.setItem("zipCode", this.zipCode)
-        localStorage.setItem("state", json.state)
-        this.manualZip = true;
-        localStorage.setItem("manualZip", "true")
-        
-        // Retry getting vendors if a plant is already selected
-        if (this.selected) {
-          this.getVendors();
-        }
-      } catch (error) {
-        console.error("Error setting location:", error);
-        alert("Error setting location. Please try again.");
       }
     },
     async getVendors() {
@@ -4147,6 +4187,22 @@ button.text {
   text-align: center;
   padding: 5px;
 }
+.enter-location-link {
+  color: #b74d15;
+  text-decoration: underline;
+  font: inherit;
+  font-style: italic;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.enter-location-link:hover {
+  color: #8f3d11;
+}
+.filters-drawer-location {
+  padding: 0 16px;
+}
 .chips button.clear {
   text-decoration: underline;
   font-size: 16px;
@@ -4258,7 +4314,7 @@ button.text {
   .browse-toolbar-row--actions {
     grid-template-columns: auto minmax(160px, 1fr) auto;
   }
-  .browse-location-button {
+  .browse-location-field {
     display: none;
   }
   .browse-sort-button.list-button .label {
@@ -4285,7 +4341,7 @@ button.text {
   .browse-toolbar {
     display: grid;
     /* Keep Sort compact and reserve enough space for the photo mode toggle */
-    grid-template-columns: 44px auto minmax(120px, 200px) 44px minmax(180px, 1fr);
+    grid-template-columns: minmax(120px, 1.1fr) auto minmax(120px, 200px) 44px minmax(180px, 1fr);
     grid-template-areas: "loc filter sort fav mode";
     column-gap: 6px;
     row-gap: 0;
@@ -4293,15 +4349,9 @@ button.text {
     margin: 10px 0 12px;
   }
 
-  .browse-location-button {
+  .browse-location-field {
     grid-area: loc;
-    width: 44px;
-    height: 44px;
-    padding: 0;
-    border-radius: 12px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    min-width: 0;
   }
 
   .browse-filter-button {
@@ -5739,8 +5789,8 @@ th {
     margin-bottom: 0;
     display: block;
   }
-  /* Desktop: use the full location bar; hide the compact icon in the toolbar */
-  .browse-location-button {
+  /* Desktop: use the full location bar; hide the compact toolbar field */
+  .browse-location-field {
     display: none;
   }
   /* Desktop: filters are always visible in the sidebar, so hide the Filter button */
@@ -6174,41 +6224,8 @@ th {
   display: flex;
   justify-content: center;
   flex-shrink: 0;
-}
-
-/* Keep default button styling for consistency; just lay out the icon/text nicely */
-.location-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 14px;
-  font-size: 14px;
-  cursor: pointer;
-}
-
-.location-btn .material-icons {
-  font-size: 16px;
-}
-
-@media screen and (max-width: 768px) {
-  .location-btn {
-    font-size: 13px;
-    padding: 8px 12px;
-  }
-}
-
-/* Phone: location selector should be icon-only to save vertical space */
-@media (max-width: 600px) {
-  .location-btn {
-    width: 44px;
-    height: 44px;
-    padding: 0;
-    border-radius: 12px;
-    justify-content: center;
-  }
-  .location-btn span:not(.material-icons) {
-    display: none;
-  }
+  max-width: 420px;
+  margin: 0 auto;
 }
 
 @media all and (min-width: 1280px) {
@@ -6226,6 +6243,8 @@ th {
   .location-section {
     width: auto;
     justify-content: flex-start;
+    max-width: 360px;
+    margin: 0;
   }
 }
 </style>

--- a/src/components/LocationSearchField.vue
+++ b/src/components/LocationSearchField.vue
@@ -1,0 +1,445 @@
+<template>
+  <div
+    class="location-field"
+    :class="[`location-field--${variant}`, { 'location-field--editing': editing }]"
+    ref="root"
+  >
+    <label v-if="showLabel" :for="inputId" class="location-field-label">
+      Location
+    </label>
+    <div class="location-field-control">
+      <span class="material-icons location-field-icon" aria-hidden="true">place</span>
+      <div class="location-field-input-wrap">
+        <input
+          :id="inputId"
+          ref="input"
+          class="location-field-input"
+          type="text"
+          inputmode="numeric"
+          maxlength="5"
+          :value="editing ? draft : appliedZip"
+          :placeholder="placeholder"
+          :disabled="disabled || resolving || externalLoading"
+          :aria-label="ariaLabel"
+          :aria-invalid="!!error"
+          :aria-describedby="error ? errorId : undefined"
+          autocomplete="postal-code"
+          @input="onInput"
+          @focus="onFocus"
+          @blur="onBlur"
+          @keydown="onKeydown"
+        />
+        <button
+          v-if="showSummaryOverlay"
+          type="button"
+          class="location-field-summary"
+          :title="summaryText"
+          tabindex="-1"
+          aria-hidden="true"
+          @mousedown.prevent="onSummaryClick"
+        >
+          {{ summaryText }}
+        </button>
+      </div>
+      <button
+        v-if="appliedZip && !resolving && !externalLoading"
+        type="button"
+        class="location-field-clear"
+        aria-label="Clear location"
+        @mousedown.prevent="onClear"
+      >
+        <span class="material-icons" aria-hidden="true">close</span>
+      </button>
+      <span
+        v-if="resolving || externalLoading"
+        class="location-field-spinner"
+        aria-hidden="true"
+      ></span>
+    </div>
+    <p v-if="error" :id="errorId" class="location-field-error" role="alert">
+      {{ error }}
+    </p>
+  </div>
+</template>
+
+<script>
+const AUTO_COMMIT_IDLE_MS = 500;
+
+let nextFieldId = 0;
+
+export default {
+  name: "LocationSearchField",
+  props: {
+    variant: {
+      type: String,
+      default: "bar",
+      validator: (value) => ["bar", "toolbar", "drawer", "inline"].includes(value),
+    },
+    appliedZip: {
+      type: String,
+      default: "",
+    },
+    appliedDisplayLocation: {
+      type: String,
+      default: "",
+    },
+    commitHandler: {
+      type: Function,
+      required: true,
+    },
+    externalLoading: {
+      type: Boolean,
+      default: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    showLabel: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["cleared"],
+  data() {
+    const fieldId = `location-field-${++nextFieldId}`;
+    return {
+      inputId: fieldId,
+      errorId: `${fieldId}-error`,
+      draft: "",
+      editing: false,
+      error: null,
+      resolving: false,
+      autoCommitTimer: null,
+      blurSuppressUntil: 0,
+    };
+  },
+  computed: {
+    placeholder() {
+      if (this.variant === "drawer") return "ZIP code";
+      if (this.variant === "toolbar") return "ZIP";
+      return "Enter ZIP code";
+    },
+    ariaLabel() {
+      if (this.summaryText) {
+        return `Location: ${this.summaryText}. Enter ZIP code to change.`;
+      }
+      return "ZIP code";
+    },
+    summaryText() {
+      const zip = (this.appliedZip || "").trim();
+      const location = (this.appliedDisplayLocation || "").trim();
+      if (location && zip) {
+        return `${location} · ${zip}`;
+      }
+      if (location) {
+        return location;
+      }
+      if (zip) {
+        return zip;
+      }
+      return "";
+    },
+    showSummaryOverlay() {
+      return !this.editing && !!this.summaryText && !this.error;
+    },
+  },
+  watch: {
+    appliedZip(next) {
+      if (!this.editing) {
+        this.draft = next || "";
+      }
+    },
+  },
+  beforeUnmount() {
+    this.clearAutoCommitTimer();
+  },
+  methods: {
+    focus() {
+      const input = this.$refs.input;
+      if (input && typeof input.focus === "function") {
+        input.focus();
+      }
+    },
+    clearAutoCommitTimer() {
+      if (this.autoCommitTimer) {
+        clearTimeout(this.autoCommitTimer);
+        this.autoCommitTimer = null;
+      }
+    },
+    scheduleAutoCommit() {
+      this.clearAutoCommitTimer();
+      if (!/^\d{5}$/.test(this.draft)) {
+        return;
+      }
+      if (this.draft === this.appliedZip) {
+        return;
+      }
+      this.autoCommitTimer = setTimeout(() => {
+        this.autoCommitTimer = null;
+        void this.tryCommit();
+      }, AUTO_COMMIT_IDLE_MS);
+    },
+    onInput(event) {
+      const digits = String(event.target.value || "").replace(/\D/g, "").slice(0, 5);
+      this.draft = digits;
+      this.error = null;
+      this.editing = true;
+      if (event.target.value !== digits) {
+        event.target.value = digits;
+      }
+      this.scheduleAutoCommit();
+    },
+    onFocus() {
+      this.editing = true;
+      this.error = null;
+      if (!this.draft) {
+        this.draft = this.appliedZip || "";
+      }
+    },
+    onBlur() {
+      if (Date.now() < this.blurSuppressUntil) {
+        return;
+      }
+      window.setTimeout(() => {
+        if (this.resolving) {
+          return;
+        }
+        this.editing = false;
+        this.draft = this.appliedZip || "";
+        this.clearAutoCommitTimer();
+      }, 120);
+    },
+    onSummaryClick() {
+      this.editing = true;
+      this.draft = this.appliedZip || "";
+      this.$nextTick(() => this.focus());
+    },
+    onKeydown(event) {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void this.tryCommit();
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.editing = false;
+        this.draft = this.appliedZip || "";
+        this.error = null;
+        this.clearAutoCommitTimer();
+        event.target.blur();
+      }
+    },
+    async onClear() {
+      this.blurSuppressUntil = Date.now() + 250;
+      this.clearAutoCommitTimer();
+      this.draft = "";
+      this.editing = true;
+      this.error = null;
+      this.$emit("cleared");
+      await this.$nextTick();
+      this.focus();
+    },
+    async tryCommit() {
+      const zip = (this.draft || "").trim();
+      if (!zip) {
+        this.error = "Enter a 5-digit ZIP code.";
+        return false;
+      }
+      if (!/^\d{5}$/.test(zip)) {
+        this.error = "ZIP code must be 5 digits.";
+        return false;
+      }
+      if (zip === this.appliedZip) {
+        this.editing = false;
+        this.error = null;
+        return true;
+      }
+
+      this.resolving = true;
+      this.error = null;
+      try {
+        await this.commitHandler(zip);
+        this.editing = false;
+        this.draft = zip;
+        return true;
+      } catch (error) {
+        this.error =
+          (error && error.message) ||
+          "Could not set location. Please try again.";
+        return false;
+      } finally {
+        this.resolving = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.location-field {
+  width: 100%;
+  min-width: 0;
+}
+
+.location-field-label {
+  display: block;
+  margin: 0 0 6px;
+  font-family: Roboto, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.62);
+}
+
+.location-field-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 10px 0 12px;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.location-field--toolbar .location-field-control {
+  min-height: 44px;
+  padding: 0 8px 0 10px;
+}
+
+.location-field--drawer .location-field-control {
+  margin-bottom: 12px;
+}
+
+.location-field-icon {
+  flex: 0 0 auto;
+  font-size: 18px;
+  color: #b74d15;
+}
+
+.location-field-input-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.location-field-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #1d2e26;
+  padding: 10px 0;
+}
+
+.location-field-input::placeholder {
+  color: rgba(0, 0, 0, 0.42);
+}
+
+.location-field-input:focus-visible {
+  outline: none;
+}
+
+.location-field-control:focus-within {
+  border-color: rgba(183, 77, 21, 0.55);
+  box-shadow: 0 0 0 3px rgba(183, 77, 21, 0.12);
+}
+
+.location-field-summary {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  padding: 10px 0;
+  border: none;
+  background: #fff;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.3;
+  color: #1d2e26;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: text;
+}
+
+.location-field-clear {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.55);
+  cursor: pointer;
+}
+
+.location-field-clear:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.78);
+}
+
+.location-field-clear:focus-visible {
+  outline: 2px solid rgba(183, 77, 21, 0.45);
+  outline-offset: 2px;
+}
+
+.location-field-clear .material-icons {
+  font-size: 18px;
+}
+
+.location-field-spinner {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(183, 77, 21, 0.2);
+  border-top-color: #b74d15;
+  border-radius: 50%;
+  animation: location-spin 0.8s linear infinite;
+}
+
+.location-field-error {
+  margin: 6px 0 0;
+  font-family: Roboto, sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #b42318;
+}
+
+.location-field--toolbar {
+  min-width: 0;
+}
+
+.location-field--toolbar .location-field-summary,
+.location-field--toolbar .location-field-input {
+  font-size: 13px;
+}
+
+.location-field--inline {
+  max-width: 280px;
+}
+
+@keyframes location-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .location-field-spinner {
+    animation: none;
+    border-top-color: #b74d15;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- Replace the zip code `prompt()` with an inline `LocationSearchField` component in the browse toolbar, utility header, and mobile filter drawer
- Support typed ZIP entry, auto-commit, clear, and display of resolved city/state alongside the applied ZIP

## Test plan
- [ ] Set location from the browse toolbar and confirm ZIP resolves to a display label
- [ ] Clear location and confirm nearby nursery results update accordingly
- [ ] On mobile, set location from the filter drawer variant
- [ ] Confirm invalid ZIP shows an inline error instead of a browser alert
- [ ] Confirm location persists across refresh via localStorage and shareable URL params when present