### PR TITLE
feat: shareable browse URLs and plant detail dialog

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -106,17 +106,22 @@
     <h1 class="large favorites" v-if="favorites">
       Favorites <span class="favorites-title-count" v-if="favoritesCount">({{ favoritesCount }})</span>
     </h1>
-    <article v-if="selected" class="selected">
-      <div class="modal-bar">
-        <span class="title">More Info</span>
-        <button
-          type="button"
-          class="material-icons router-button close-nav"
-          aria-label="Close plant details"
-          @click="closePlantDetail"
-        >close</button>
+    <PlantDetailDialog
+      :open="!!selectedName"
+      :title="detailTitle"
+      :position-label="feedPositionLabel"
+      :has-previous="feedHasPrevious"
+      :has-next="feedHasNext"
+      :loading="detailLoading"
+      @close="closePlantDetail"
+      @previous="navigateFeedPlant(-1)"
+      @next="navigateFeedPlant(1)"
+    >
+      <div v-if="detailError" class="plant-detail-error" role="alert">
+        <p>{{ detailError }}</p>
+        <button type="button" class="primary" @click="closePlantDetail">Close</button>
       </div>
-      <div class="two-up">
+      <div v-else-if="selected" class="two-up">
         <div class="two-up-image" :style="selectedImageStyle(selected)"></div>
         <div class="two-up-text">
           <h1>
@@ -124,6 +129,11 @@
             }}<button
               @click="toggleFavorite(selected._id)"
               class="favorite-selected text"
+              :aria-label="
+                $store.state.favorites.has(selected._id)
+                  ? `Remove ${selected['Common Name']} from favorites`
+                  : `Add ${selected['Common Name']} to favorites`
+              "
             >
               <span class="material-icons material-align">{{
                 renderFavorite(selected._id)
@@ -231,7 +241,24 @@
           </p>
         </div>
       </div>
-    </article>
+      <template #footer>
+        <button
+          v-if="selected"
+          type="button"
+          class="plant-detail-footer-favorite primary"
+          @click="toggleFavorite(selected._id)"
+        >
+          <span class="material-icons material-align" aria-hidden="true">{{
+            renderFavorite(selected._id)
+          }}</span>
+          <span>{{
+            $store.state.favorites.has(selected._id)
+              ? "Remove from favorites"
+              : "Add to favorites"
+          }}</span>
+        </button>
+      </template>
+    </PlantDetailDialog>
     <main :class="mainClasses" ref="mainContent">
         <div class="controls">
           <!-- Favorites toolbar: preferences + actions -->
@@ -792,6 +819,7 @@ import Header from "./Header.vue";
 import Menu from "./Menu.vue";
 import BulkAddFavoritesModal from "./BulkAddFavoritesModal.vue";
 import BrowseResultStates from "./BrowseResultStates.vue";
+import PlantDetailDialog from "./PlantDetailDialog.vue";
 import {
   browseRouteQueriesMatch,
   DEFAULT_SORT,
@@ -844,6 +872,7 @@ export default {
     Menu,
     BulkAddFavoritesModal,
     BrowseResultStates,
+    PlantDetailDialog,
     Trash2,
   },
   props: {
@@ -1065,6 +1094,8 @@ export default {
       manualZip: false,
       updatingCounts: false,
       selected: null,
+      detailLoading: false,
+      detailError: null,
       localStoreLinks: [],
       baseSorts,
       sortIsOpen: false,
@@ -1094,6 +1125,46 @@ export default {
   computed: {
     selectedName() {
       return this.$route.params.name;
+    },
+    detailTitle() {
+      if (this.selected?.["Common Name"]) {
+        return this.selected["Common Name"];
+      }
+      if (this.selectedName) {
+        return this.selectedName;
+      }
+      return "More Info";
+    },
+    selectedFeedIndex() {
+      if (!this.selectedName || !this.results.length) {
+        return -1;
+      }
+      const index = this.results.findIndex(
+        (result) => result["Scientific Name"] === this.selectedName
+      );
+      if (index >= 0) {
+        return index;
+      }
+      if (this.selected?._id) {
+        return this.results.findIndex((result) => result._id === this.selected._id);
+      }
+      return -1;
+    },
+    feedHasPrevious() {
+      return this.selectedFeedIndex > 0;
+    },
+    feedHasNext() {
+      return (
+        this.selectedFeedIndex >= 0 &&
+        this.selectedFeedIndex < this.results.length - 1
+      );
+    },
+    feedPositionLabel() {
+      if (this.selectedFeedIndex < 0) {
+        return "";
+      }
+      const total = this.total > 0 ? this.total : this.results.length;
+      return `${this.selectedFeedIndex + 1} of ${total}`;
     },
     filtersForPane() {
       return (this.filters || []).filter((f) => !f.hideInFilterPane);
@@ -1754,11 +1825,50 @@ export default {
         });
     },
     closePlantDetail() {
+      if (this.$route.path.startsWith("/plants/")) {
+        this.$router.push(this.browseHomeLocation());
+        return;
+      }
       if (typeof window !== "undefined" && window.history.length > 1) {
         this.$router.back();
         return;
       }
       this.$router.push(this.browseHomeLocation());
+    },
+    plantRouteLocation(plant) {
+      const scientificName = encodeURIComponent(plant["Scientific Name"]);
+      const queryString = serializeBrowseSearchParams(
+        this.buildBrowseSnapshot(),
+        this.filters,
+        this.defaultFilterValues
+      );
+      return {
+        path: `/plants/${scientificName}`,
+        query: queryStringToRouteQuery(queryString),
+      };
+    },
+    openPlantDetail(plant) {
+      const destination = this.plantRouteLocation(plant);
+      const detailAlreadyOpen = !!this.selectedName;
+      this.syncingBrowseUrl = true;
+      const navigate = detailAlreadyOpen
+        ? this.$router.replace
+        : this.$router.push;
+      navigate
+        .call(this.$router, destination)
+        .catch(() => {})
+        .finally(() => {
+          this.$nextTick(() => {
+            this.syncingBrowseUrl = false;
+          });
+        });
+    },
+    navigateFeedPlant(delta) {
+      const index = this.selectedFeedIndex;
+      if (index < 0) return;
+      const nextPlant = this.results[index + delta];
+      if (!nextPlant) return;
+      this.openPlantDetail(nextPlant);
     },
     setDefaultZipCode() {
       // Set default zip code to 19355 (Malvern, PA)
@@ -2842,12 +2952,12 @@ export default {
         const selection = window.getSelection();
         if (selection && String(selection).trim()) return;
       }
-      this.$router.push(this.plantLink(result));
+      this.openPlantDetail(result);
     },
     onTileKeyActivate(result, evt) {
       // Space should not scroll the page when a tile is focused.
       if (evt && typeof evt.preventDefault === "function") evt.preventDefault();
-      this.$router.push(this.plantLink(result));
+      this.openPlantDetail(result);
     },
     imageStyle(image, preview = true) {
       const url = this.imageUrl(image, preview);
@@ -2860,15 +2970,33 @@ export default {
     async fetchSelectedIfNeeded() {
       if (!this.selectedName) {
         this.selected = null;
+        this.detailLoading = false;
+        this.detailError = null;
         this.$store.commit("setSelectedIsOpen", false);
-      } else {
-        // Could be optimized away in some cases, but not all
-        // (direct links from Google for example), so let's stick to
-        // what definitely works for now
-        const response = await fetch(`/api/v1/plants/${this.selectedName}`);
+        return;
+      }
+
+      this.detailLoading = true;
+      this.detailError = null;
+      try {
+        const response = await fetch(
+          `/api/v1/plants/${encodeURIComponent(this.selectedName)}`
+        );
+        if (!response.ok) {
+          throw new Error("Could not load this plant. It may have been removed.");
+        }
         this.selected = await response.json();
         this.getVendors();
         this.$store.commit("setSelectedIsOpen", true);
+      } catch (error) {
+        console.error("Error loading plant detail:", error);
+        this.selected = null;
+        this.detailError =
+          (error && error.message) ||
+          "Could not load this plant. Please try again.";
+        this.$store.commit("setSelectedIsOpen", false);
+      } finally {
+        this.detailLoading = false;
       }
     },
     async determineFilterCountsAndSubmit() {
@@ -3122,7 +3250,7 @@ export default {
         this.showAutocomplete = false;
         this.submit();
       } else if (item.action === "navigateToPlant") {
-        this.$router.push(this.plantLink({ "Scientific Name": item.plantId }));
+        this.openPlantDetail({ "Scientific Name": item.plantId });
         this.showAutocomplete = false;
       }
     },
@@ -4231,14 +4359,11 @@ ${htmlLines.join("\n")}
       return groups;
     },
     plantLink(plant) {
-      const scientificName = encodeURIComponent(plant["Scientific Name"]);
-      const queryString = serializeBrowseSearchParams(
-        this.buildBrowseSnapshot(),
-        this.filters,
-        this.defaultFilterValues
-      );
-      const path = `/plants/${scientificName}`;
-      return queryString ? `${path}?${queryString}` : path;
+      const location = this.plantRouteLocation(plant);
+      const queryString = routeQueryToSearchParams(location.query).toString();
+      return queryString
+        ? `${location.path}?${queryString}`
+        : location.path;
     },
   },
 };
@@ -5626,6 +5751,26 @@ th {
   width: 100%;
 }
 
+.plant-detail-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-height: 40vh;
+  padding: 32px 16px;
+  text-align: center;
+  font-family: Roboto, sans-serif;
+}
+
+.plant-detail-footer-favorite {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 
 .modal-bar {
   padding: 12px;
@@ -5655,27 +5800,20 @@ th {
   line-height: 1;
 }
 
-.selected {
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  width: 100%;
-  height: 100vh;
-  background-color: #fcf9f4;
-  z-index: 1100;
-  overflow: scroll;
+:deep(.plant-detail-dialog) {
+  /* layout handled by PlantDetailDialog */
 }
 
-.favorite-selected > * {
-  color: #b74d15;
-  font-weight: normal;
-}
-
-.selected .two-up h1 {
+:deep(.plant-detail-dialog) .two-up h1 {
   font-family: Arvo;
   font-size: 24px;
   margin: 16px 0 4px 0;
   text-align: left;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-right: 48px;
 }
 
 .favorite-selected.text {
@@ -5686,14 +5824,32 @@ th {
   font-size: 16px;
 }
 
-.selected .two-up h2 {
+:deep(.plant-detail-dialog) .favorite-selected.text {
+  position: static;
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.favorite-selected > * {
+  color: #b74d15;
+  font-weight: normal;
+}
+
+@media (max-width: 767px) {
+  .favorite-selected.text {
+    display: none;
+  }
+}
+
+:deep(.plant-detail-dialog) .two-up h2 {
   font-size: 20px;
   font-family: Roboto;
   line-height: 1;
   margin: 0 0 24px;
 }
 
-.selected .two-up h3 {
+:deep(.plant-detail-dialog) .two-up h3 {
   font-size: 20px;
   font-family: Roboto;
   line-height: 1;
@@ -5701,7 +5857,7 @@ th {
   margin: 0 0 8px 0;
 }
 
-.selected .two-up h4 {
+:deep(.plant-detail-dialog) .two-up h4 {
   font-size: 20px;
   font-family: Roboto;
   line-height: 1;
@@ -5709,7 +5865,7 @@ th {
   margin: 0 0 8px 0;
 }
 
-.selected .two-up p {
+:deep(.plant-detail-dialog) .two-up p {
   font-size: 16px;
   font-family: Lato;
   line-height: 20px;
@@ -5718,6 +5874,36 @@ th {
 
 .two-up {
   display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+@media (min-width: 640px) {
+  :deep(.plant-detail-dialog) .plant-detail-scroll {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  :deep(.plant-detail-dialog) .two-up {
+    flex: 1 1 auto;
+    flex-direction: row;
+    align-items: stretch;
+    min-height: 0;
+    height: 100%;
+  }
+
+  :deep(.plant-detail-dialog) .two-up-image {
+    flex: 1 1 48%;
+    min-width: 0;
+    min-height: 320px;
+  }
+
+  :deep(.plant-detail-dialog) .two-up-text {
+    flex: 1 1 52%;
+    min-width: 0;
+    overflow-y: auto;
+  }
 }
 
 .two-up-image {
@@ -5728,9 +5914,20 @@ th {
   display: none;
 }
 
-.selected .two-up .two-up-image {
-  /* flex-basis doesn't do the job at least on iPhone */
-  min-height: 40vh;
+:deep(.plant-detail-dialog) .two-up .two-up-image {
+  min-height: 280px;
+}
+
+@media (min-width: 640px) {
+  :deep(.plant-detail-dialog) .two-up-text {
+    padding-top: 56px;
+  }
+
+  :deep(.plant-detail-dialog) .two-up .two-up-image {
+    min-height: 0;
+    height: auto;
+    aspect-ratio: auto;
+  }
 }
 
 .two-up-text {
@@ -5842,21 +6039,21 @@ th {
   color: #b74d15;
   flex-grow: 1;
   flex-basis: 0;
-  height: 380px;
   background-color: white;
+}
+
+:deep(.plant-detail-dialog) .two-up-image {
   background-size: cover;
   background-position: center;
 }
 
-.selected .two-up {
-  height: calc(100vh - 96px);
-}
-
-.selected .two-up {
+:deep(.plant-detail-dialog) .two-up {
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
 }
 
-.selected .two-up > * {
+:deep(.plant-detail-dialog) .two-up > * {
   background-color: #fcf9f4;
   color: black;
   height: auto;
@@ -6171,40 +6368,38 @@ th {
     padding: 40px;
   }
 
-  .selected {
-    overflow: hidden;
-  }
-
-  .selected .two-up-text {
+  :deep(.plant-detail-dialog) .two-up-text {
     overflow: scroll;
+    padding-top: 56px;
   }
 
-  .selected .two-up h1,
-  .selected .two-up h2,
-  .selected .two-up h3,
-  .selected .two-up h4 {
+  :deep(.plant-detail-dialog) .two-up h1,
+  :deep(.plant-detail-dialog) .two-up h2,
+  :deep(.plant-detail-dialog) .two-up h3,
+  :deep(.plant-detail-dialog) .two-up h4 {
     font-family: Roboto;
     text-align: left;
   }
 
-  .selected .two-up h1 {
+  :deep(.plant-detail-dialog) .two-up h1 {
     font-family: Roboto;
     font-size: 40px;
     margin: 0 0 12px 0;
+    padding-right: 0;
   }
 
-  .selected .two-up h2 {
+  :deep(.plant-detail-dialog) .two-up h2 {
     font-size: 24px;
     margin: 0 0 32px 0;
   }
 
-  .selected .two-up h3 {
+  :deep(.plant-detail-dialog) .two-up h3 {
     font-size: 24px;
     font-weight: 500;
     margin: 24px 0 8px 0;
   }
 
-  .selected .two-up p {
+  :deep(.plant-detail-dialog) .two-up p {
     font-size: 20px;
     line-height: 24px;
     margin: 0 0 16px 0;
@@ -6249,34 +6444,9 @@ th {
     color: black;
     transform: translate(0, -12px);
   }
-  .selected {
-    flex-direction: row;
-    width: calc(100vw - 64px);
-    height: calc(100vh - 32px);
-    margin: 16px 32px;
-  }
-  .selected .two-up {
-    height: auto;
-  }
-  .selected .info {
-    order: 1;
-    flex-basis: 0;
-    flex-grow: 1;
-  }
-  .selected .photo {
-    order: 2;
-    flex-basis: 0;
-    flex-grow: 1;
-  }
-  .selected .two-up {
+  :deep(.plant-detail-dialog) .two-up {
     flex-direction: row;
     height: 100%;
-  }
-  .selected .two-up-image {
-    order: 2;
-  }
-  .selected .two-up-text {
-    order: 1;
   }
   .chips {
     /* Per Cristina desktop chips wrap, they do not scroll */

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -109,9 +109,12 @@
     <article v-if="selected" class="selected">
       <div class="modal-bar">
         <span class="title">More Info</span>
-        <router-link to="/" class="material-icons router-button close-nav"
-          >close</router-link
-        >
+        <button
+          type="button"
+          class="material-icons router-button close-nav"
+          aria-label="Close plant details"
+          @click="closePlantDetail"
+        >close</button>
       </div>
       <div class="two-up">
         <div class="two-up-image" :style="selectedImageStyle(selected)"></div>
@@ -789,6 +792,14 @@ import Header from "./Header.vue";
 import Menu from "./Menu.vue";
 import BulkAddFavoritesModal from "./BulkAddFavoritesModal.vue";
 import BrowseResultStates from "./BrowseResultStates.vue";
+import {
+  browseRouteQueriesMatch,
+  DEFAULT_SORT,
+  parseBrowseSearchParams,
+  queryStringToRouteQuery,
+  routeQueryToSearchParams,
+  serializeBrowseSearchParams,
+} from "../lib/browse-search-params.js";
 import { Trash2 } from "lucide-vue-next";
 
 const twoUpImageCredits = [
@@ -1076,6 +1087,8 @@ export default {
       autocompleteTimeout: null,
       hasExtractedFilters: false,
       suppressFilterWatcher: false, // Flag to prevent watcher from triggering submit during programmatic updates
+      syncingBrowseUrl: false,
+      browseUrlReady: false,
     };
   },
   computed: {
@@ -1284,6 +1297,14 @@ export default {
     selectedName() {
       this.fetchSelectedIfNeeded();
     },
+    "$route.query": {
+      async handler(newQuery, oldQuery) {
+        if (!this.browseUrlReady || this.favorites || this.syncingBrowseUrl) return;
+        if (!oldQuery || browseRouteQueriesMatch(newQuery, oldQuery)) return;
+        await this.applyBrowseSnapshotFromRoute();
+        this.submit();
+      },
+    },
     favorites() {
       this.determineFilterCountsAndSubmit();
       // Favorites view does not page; ensure infinite scroll is correctly enabled/disabled.
@@ -1409,6 +1430,7 @@ export default {
   // Server only
   async serverPrefetch() {
     try {
+      await this.applyBrowseSnapshotFromRoute();
       await this.determineFilterCounts();
       this.page = 1;
       this.loadedAll = false;
@@ -1443,14 +1465,21 @@ export default {
     this.displayLocation = localStorage.getItem("displayLocation") || "";
     this.zipCode = localStorage.getItem("zipCode") || "";
     this.manualZip = localStorage.getItem("manualZip") === "true";
-    this.filterValues["States"] = [localStorage.getItem("state")];
-
-    // Pre-set the default zip code to ensure immediate response
-    if (!this.zipCode) {
-      this.zipCode = "19355";
+    const storedState = localStorage.getItem("state");
+    if (storedState) {
+      this.filterValues["States"] = [storedState];
     }
-    
-    if (!this.manualZip && "geolocation" in navigator) {
+
+    await this.applyBrowseSnapshotFromRoute();
+    const urlZip = this.$route.query.zip;
+
+    if (!urlZip) {
+      // Pre-set the default zip code to ensure immediate response
+      if (!this.zipCode) {
+        this.zipCode = "19355";
+      }
+
+      if (!this.manualZip && "geolocation" in navigator) {
       // Set loading state
       this.isLoadingLocation = true;
       
@@ -1516,14 +1545,19 @@ export default {
         },
         { timeout: 3000, maximumAge: 60000 } // 3s timeout, cache for 1 minute
       );
-    } else if (!this.displayLocation) {
-      // Geolocation not available or user chose manual zip
-      this.setDefaultZipCode();
+      } else if (!this.displayLocation) {
+        // Geolocation not available or user chose manual zip
+        this.setDefaultZipCode();
+      }
+    } else if (this.zipCode && !this.displayLocation) {
+      await this.refreshDisplayLocationForZip(this.zipCode, { persist: true });
     }
 
     await this.determineFilterCountsAndSubmit();
     await this.fetchSelectedIfNeeded();
     this.setupInfiniteScroll();
+    this.browseUrlReady = true;
+    this.syncBrowseUrl({ replace: true });
   },
   beforeUnmount() {
     this.teardownInfiniteScroll();
@@ -1596,6 +1630,135 @@ export default {
         cleanedParams[key] = value;
       }
       return cleanedParams;
+    },
+    buildBrowseSnapshot() {
+      return {
+        q: (this.activeSearch || "").trim(),
+        sort: this.sort || DEFAULT_SORT,
+        zip: (this.zipCode || "").trim(),
+        loc: (this.displayLocation || "").trim(),
+        filterValues: { ...this.filterValues },
+      };
+    },
+    async applyBrowseSnapshotFromRoute() {
+      if (this.favorites) return false;
+      const params = routeQueryToSearchParams(this.$route.query);
+      if ([...params.keys()].length === 0) return false;
+      const snapshot = parseBrowseSearchParams(params);
+      await this.applyBrowseSnapshot(snapshot);
+      return true;
+    },
+    async applyBrowseSnapshot(snapshot) {
+      this.suppressFilterWatcher = true;
+      try {
+        if (snapshot.q) {
+          this.q = snapshot.q;
+          this.activeSearch = snapshot.q;
+          this.hasExtractedFilters = false;
+        }
+        if (snapshot.sort) {
+          this.sort = snapshot.sort;
+          this.previousSort =
+            snapshot.sort === "Sort by Search Relevance"
+              ? DEFAULT_SORT
+              : snapshot.sort;
+        }
+        for (const [filterName, value] of Object.entries(
+          snapshot.filterValues || {}
+        )) {
+          this.filterValues[filterName] = value;
+        }
+        if (snapshot.zip) {
+          this.zipCode = snapshot.zip;
+          this.manualZip = true;
+          localStorage.setItem("zipCode", snapshot.zip);
+          localStorage.setItem("manualZip", "true");
+          if (snapshot.loc) {
+            this.displayLocation = snapshot.loc;
+            localStorage.setItem("displayLocation", snapshot.loc);
+          }
+          const states = snapshot.filterValues?.States;
+          if (Array.isArray(states) && states.length > 0) {
+            localStorage.setItem("state", states[0]);
+          } else if (!snapshot.loc) {
+            await this.refreshDisplayLocationForZip(snapshot.zip, {
+              persist: true,
+            });
+          }
+        }
+      } finally {
+        await this.$nextTick();
+        this.suppressFilterWatcher = false;
+      }
+    },
+    async refreshDisplayLocationForZip(zip, { persist = false } = {}) {
+      try {
+        const response = await fetch("/get-city", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ zipCode: zip }),
+        });
+        if (!response.ok) return;
+        const json = await response.json();
+        this.filterValues["States"] = [json.state];
+        this.displayLocation = `${json.city}, ${json.state}`;
+        if (persist) {
+          localStorage.setItem("zipCode", zip);
+          localStorage.setItem("state", json.state);
+          localStorage.setItem("displayLocation", this.displayLocation);
+        }
+      } catch (error) {
+        console.error("Error resolving ZIP location:", error);
+      }
+    },
+    browseHomeLocation() {
+      const queryString = serializeBrowseSearchParams(
+        this.buildBrowseSnapshot(),
+        this.filters,
+        this.defaultFilterValues
+      );
+      return {
+        path: "/",
+        query: queryStringToRouteQuery(queryString),
+      };
+    },
+    syncBrowseUrl({ replace = true } = {}) {
+      if (this.favorites || this.syncingBrowseUrl || typeof window === "undefined") {
+        return;
+      }
+      const queryString = serializeBrowseSearchParams(
+        this.buildBrowseSnapshot(),
+        this.filters,
+        this.defaultFilterValues
+      );
+      const nextQuery = queryStringToRouteQuery(queryString);
+      if (browseRouteQueriesMatch(this.$route.query, nextQuery)) {
+        return;
+      }
+
+      const path = this.selectedName
+        ? `/plants/${encodeURIComponent(this.selectedName)}`
+        : "/";
+
+      this.syncingBrowseUrl = true;
+      const navigate = replace ? this.$router.replace : this.$router.push;
+      navigate
+        .call(this.$router, { path, query: nextQuery })
+        .catch(() => {})
+        .finally(() => {
+          this.$nextTick(() => {
+            this.syncingBrowseUrl = false;
+          });
+        });
+    },
+    closePlantDetail() {
+      if (typeof window !== "undefined" && window.history.length > 1) {
+        this.$router.back();
+        return;
+      }
+      this.$router.push(this.browseHomeLocation());
     },
     setDefaultZipCode() {
       // Set default zip code to 19355 (Malvern, PA)
@@ -1684,6 +1847,7 @@ export default {
         if (this.selected) {
           this.getVendors();
         }
+        this.submit();
       } catch (error) {
         console.error("Error setting location:", error);
         alert("Error setting location. Please try again.");
@@ -2958,8 +3122,7 @@ export default {
         this.showAutocomplete = false;
         this.submit();
       } else if (item.action === "navigateToPlant") {
-        // Navigate to plant detail page
-        this.$router.push(`/plants/${item.plantId}`);
+        this.$router.push(this.plantLink({ "Scientific Name": item.plantId }));
         this.showAutocomplete = false;
       }
     },
@@ -2970,8 +3133,8 @@ export default {
       this.hasExtractedFilters = false;
       this.q = "";
       // Navigate to home if not already there
-      if (this.$route.path !== '/') {
-        this.$router.push('/').then(() => {
+      if (this.$route.path !== "/") {
+        this.$router.push(this.browseHomeLocation()).then(() => {
           this.$nextTick(() => {
             this.addFilterValue("Genus", genus);
           });
@@ -2987,8 +3150,8 @@ export default {
       this.hasExtractedFilters = false;
       this.q = "";
       // Navigate to home if not already there
-      if (this.$route.path !== '/') {
-        this.$router.push('/').then(() => {
+      if (this.$route.path !== "/") {
+        this.$router.push(this.browseHomeLocation()).then(() => {
           this.$nextTick(() => {
             this.addFilterValue("Family", family);
           });
@@ -3047,6 +3210,7 @@ export default {
 
         // Fetch new data and replace results when it arrives
         this.fetchPage(true);
+        this.syncBrowseUrl({ replace: true });
 
         this.submitTimeout = null;
         
@@ -4067,7 +4231,14 @@ ${htmlLines.join("\n")}
       return groups;
     },
     plantLink(plant) {
-      return `/plants/${plant["Scientific Name"]}`;
+      const scientificName = encodeURIComponent(plant["Scientific Name"]);
+      const queryString = serializeBrowseSearchParams(
+        this.buildBrowseSnapshot(),
+        this.filters,
+        this.defaultFilterValues
+      );
+      const path = `/plants/${scientificName}`;
+      return queryString ? `${path}?${queryString}` : path;
     },
   },
 };
@@ -5477,6 +5648,11 @@ th {
   right: 16px;
   text-decoration: none;
   color: black;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
 }
 
 .selected {

--- a/src/components/PlantDetailDialog.vue
+++ b/src/components/PlantDetailDialog.vue
@@ -1,0 +1,467 @@
+<template>
+  <div
+    v-if="open"
+    class="plant-detail-overlay"
+    role="presentation"
+    @mousedown.self="emitClose"
+  >
+    <button
+      v-if="hasPrevious"
+      type="button"
+      class="plant-detail-nav plant-detail-nav--prev"
+      aria-label="Previous plant"
+      data-plant-detail-nav
+      @click="$emit('previous')"
+    >
+      <span class="material-icons" aria-hidden="true">chevron_left</span>
+    </button>
+
+    <div
+      ref="dialogEl"
+      class="plant-detail-dialog selected"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="plant-detail-title"
+      :aria-busy="loading ? 'true' : 'false'"
+      @keydown="onKeydown"
+      @keydown.tab="handleTab"
+    >
+      <span
+        class="plant-detail-focus-sentinel"
+        tabindex="0"
+        aria-hidden="true"
+        @focus="focusLast"
+      ></span>
+
+      <h2 id="plant-detail-title" class="plant-detail-sr-title">{{ title }}</h2>
+
+      <p
+        v-if="positionLabel"
+        class="plant-detail-position"
+        aria-live="polite"
+      >
+        {{ positionLabel }}
+      </p>
+
+      <div class="plant-detail-toolbar" role="presentation">
+        <button
+          type="button"
+          class="plant-detail-close"
+          aria-label="Close plant details"
+          @click="emitClose"
+        >
+          <span class="material-icons" aria-hidden="true">close</span>
+        </button>
+      </div>
+
+      <div
+        ref="scrollEl"
+        class="plant-detail-scroll"
+        @touchstart.passive="onTouchStart"
+        @touchend.passive="onTouchEnd"
+      >
+        <div v-if="loading" class="plant-detail-loading" role="status" aria-live="polite">
+          <span class="plant-detail-loading-spinner" aria-hidden="true"></span>
+          Loading plant details…
+        </div>
+        <slot v-else />
+      </div>
+
+      <footer v-if="$slots.footer" class="plant-detail-footer">
+        <slot name="footer" />
+      </footer>
+
+      <span
+        class="plant-detail-focus-sentinel"
+        tabindex="0"
+        aria-hidden="true"
+        @focus="focusFirst"
+      ></span>
+    </div>
+
+    <button
+      v-if="hasNext"
+      type="button"
+      class="plant-detail-nav plant-detail-nav--next"
+      aria-label="Next plant"
+      data-plant-detail-nav
+      @click="$emit('next')"
+    >
+      <span class="material-icons" aria-hidden="true">chevron_right</span>
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PlantDetailDialog",
+  props: {
+    open: {
+      type: Boolean,
+      default: false,
+    },
+    title: {
+      type: String,
+      default: "More Info",
+    },
+    positionLabel: {
+      type: String,
+      default: "",
+    },
+    hasPrevious: {
+      type: Boolean,
+      default: false,
+    },
+    hasNext: {
+      type: Boolean,
+      default: false,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["close", "previous", "next"],
+  data() {
+    return {
+      touchStartX: 0,
+      touchStartY: 0,
+      touchStartScroll: 0,
+      previousFocus: null,
+      bodyOverflow: "",
+    };
+  },
+  watch: {
+    open(isOpen) {
+      if (typeof document === "undefined") return;
+      if (isOpen) {
+        this.previousFocus = document.activeElement;
+        this.bodyOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        this.$nextTick(() => this.focusFirst());
+      } else {
+        document.body.style.overflow = this.bodyOverflow || "";
+        this.restoreFocus();
+      }
+    },
+  },
+  beforeUnmount() {
+    if (typeof document === "undefined") return;
+    document.body.style.overflow = this.bodyOverflow || "";
+  },
+  methods: {
+    emitClose() {
+      this.$emit("close");
+    },
+    restoreFocus() {
+      const el = this.previousFocus;
+      this.previousFocus = null;
+      if (el && typeof el.focus === "function") {
+        el.focus();
+      }
+    },
+    focusableElements() {
+      const root = this.$refs.dialogEl;
+      if (!root) return [];
+      return Array.from(
+        root.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => !el.disabled && el.offsetParent !== null);
+    },
+    async focusFirst() {
+      await this.$nextTick();
+      const focusables = this.focusableElements();
+      const closeButton = this.$refs.dialogEl?.querySelector(".plant-detail-close");
+      (closeButton || focusables[0])?.focus?.();
+    },
+    async focusLast() {
+      await this.$nextTick();
+      const focusables = this.focusableElements();
+      const last = focusables[focusables.length - 1];
+      last?.focus?.();
+    },
+    handleTab(event) {
+      const focusables = this.focusableElements();
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    onKeydown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.emitClose();
+        return;
+      }
+      if (event.key === "ArrowLeft" && this.hasPrevious) {
+        event.preventDefault();
+        this.$emit("previous");
+        return;
+      }
+      if (event.key === "ArrowRight" && this.hasNext) {
+        event.preventDefault();
+        this.$emit("next");
+      }
+    },
+    onTouchStart(event) {
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
+      this.touchStartX = touch.clientX;
+      this.touchStartY = touch.clientY;
+      this.touchStartScroll = this.$refs.scrollEl?.scrollTop ?? 0;
+    },
+    onTouchEnd(event) {
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
+      const dx = touch.clientX - this.touchStartX;
+      const dy = touch.clientY - this.touchStartY;
+      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 60) {
+        if (dx < 0 && this.hasNext) {
+          this.$emit("next");
+        } else if (dx > 0 && this.hasPrevious) {
+          this.$emit("previous");
+        }
+        return;
+      }
+      if (
+        dy > 80 &&
+        Math.abs(dx) < 40 &&
+        (this.$refs.scrollEl?.scrollTop ?? 0) <= 0 &&
+        this.touchStartScroll <= 0
+      ) {
+        this.emitClose();
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.plant-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: max(16px, env(safe-area-inset-top, 0px)) 16px
+    max(16px, env(safe-area-inset-bottom, 0px));
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.plant-detail-dialog {
+  position: relative;
+  flex: 1 1 auto;
+  width: min(64rem, 100%);
+  max-width: min(64rem, calc(100vw - 7rem));
+  height: min(90vh, calc(100dvh - 2rem));
+  max-height: 90vh;
+  background-color: #fcf9f4;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.plant-detail-sr-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.plant-detail-toolbar {
+  position: absolute;
+  inset: 0 0 auto 0;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  padding: max(12px, env(safe-area-inset-top, 0px)) 12px 0;
+  pointer-events: none;
+}
+
+.plant-detail-close {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 999px;
+  background: #fff;
+  color: #1d2e26;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.plant-detail-close .material-icons {
+  font-size: 22px;
+}
+
+.plant-detail-close:hover {
+  background: #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22);
+}
+
+.plant-detail-close:focus-visible {
+  outline: 3px solid rgba(183, 77, 21, 0.45);
+  outline-offset: 2px;
+}
+
+.plant-detail-position {
+  position: absolute;
+  top: max(16px, env(safe-area-inset-top, 0px));
+  left: 16px;
+  z-index: 19;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  font-family: Roboto, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.55);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.1);
+}
+
+.plant-detail-scroll {
+  flex: 1 1 auto;
+  overflow: auto;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.plant-detail-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 40vh;
+  padding: 32px 16px;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.plant-detail-loading-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(183, 77, 21, 0.2);
+  border-top-color: #b74d15;
+  border-radius: 50%;
+  animation: plant-detail-spin 0.8s linear infinite;
+}
+
+.plant-detail-footer {
+  flex: 0 0 auto;
+  display: none;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  background: #fcf9f4;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.plant-detail-focus-sentinel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.plant-detail-nav {
+  display: none;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #1d2e26;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+}
+
+.plant-detail-nav:focus-visible {
+  outline: 3px solid rgba(183, 77, 21, 0.4);
+  outline-offset: 2px;
+}
+
+.plant-detail-nav .material-icons {
+  font-size: 28px;
+}
+
+@media (min-width: 640px) {
+  .plant-detail-nav {
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 1800px) {
+  .plant-detail-dialog {
+    max-width: min(96rem, calc(90vh * 4 / 3));
+    width: min(96rem, calc(100vw - 4rem));
+  }
+}
+
+@media (max-width: 639px) {
+  .plant-detail-overlay {
+    padding: 0;
+    gap: 0;
+    align-items: stretch;
+  }
+
+  .plant-detail-dialog {
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .plant-detail-footer {
+    display: block;
+  }
+
+  .plant-detail-scroll {
+    padding-bottom: 8px;
+  }
+}
+
+@keyframes plant-detail-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plant-detail-loading-spinner {
+    animation: none;
+    border-top-color: #b74d15;
+  }
+}
+</style>

--- a/src/lib/browse-search-params.js
+++ b/src/lib/browse-search-params.js
@@ -1,0 +1,240 @@
+/**
+ * Serialize / parse browse state into shareable URL query params.
+ * Used on `/` and `/plants/:name` so filtered views and detail stay in sync.
+ */
+
+const DEFAULT_SORT = "Sort by Recommendation Score";
+
+const SORT_TO_SLUG = {
+  [DEFAULT_SORT]: "rec",
+  "Sort by Common Name (A-Z)": "name-az",
+  "Sort by Common Name (Z-A)": "name-za",
+  "Sort by Scientific Name (A-Z)": "sci-az",
+  "Sort by Scientific Name (Z-A)": "sci-za",
+  "Sort by Height (Tallest First)": "ht-desc",
+  "Sort by Height (Shortest First)": "ht-asc",
+  "Sort by Spread (Widest First)": "sp-desc",
+  "Sort by Spread (Thinnest First)": "sp-asc",
+  "Sort by Search Relevance": "relevance",
+};
+
+const SLUG_TO_SORT = Object.fromEntries(
+  Object.entries(SORT_TO_SLUG).map(([sort, slug]) => [slug, sort])
+);
+
+/** @type {Record<string, string>} */
+const ARRAY_FILTER_PARAM = {
+  "Sun Exposure Flags": "sun",
+  "Soil Moisture Flags": "soil",
+  "Plant Type Flags": "type",
+  "Life Cycle Flags": "life",
+  "Pollinator Flags": "poll",
+  "Flower Color Flags": "color",
+  "Availability Flags": "avail",
+  Genus: "genus",
+  Family: "family",
+  States: "state",
+  Superplant: "super",
+  Showy: "showy",
+};
+
+/** @type {Record<string, string>} */
+const RANGE_FILTER_PARAM = {
+  "Flowering Months": "bloom",
+  "Height (feet)": "height",
+  "Spread (feet)": "spread",
+};
+
+const PARAM_TO_ARRAY_FILTER = Object.fromEntries(
+  Object.entries(ARRAY_FILTER_PARAM).map(([name, param]) => [param, name])
+);
+
+const PARAM_TO_RANGE_FILTER = Object.fromEntries(
+  Object.entries(RANGE_FILTER_PARAM).map(([name, param]) => [param, name])
+);
+
+const FLOWERING_MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function splitComma(value) {
+  if (!value || !String(value).trim()) return [];
+  return String(value)
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseRange(value) {
+  const match = String(value || "").match(/^(-?\d+)-(-?\d+)$/);
+  if (!match) return null;
+  const min = Number.parseInt(match[1], 10);
+  const max = Number.parseInt(match[2], 10);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  return { min: Math.min(min, max), max: Math.max(min, max) };
+}
+
+function formatRange(range) {
+  if (!range || typeof range.min !== "number" || typeof range.max !== "number") {
+    return "";
+  }
+  return `${range.min}-${range.max}`;
+}
+
+function isRangeActive(filter, value) {
+  if (!filter || !filter.range || !value) return false;
+  if (typeof filter.min !== "number" || typeof filter.max !== "number") {
+    return true;
+  }
+  return value.min !== filter.min || value.max !== filter.max;
+}
+
+function isArrayActive(defaultValues, filterName, value) {
+  const current = Array.isArray(value) ? value : [];
+  const defaults = defaultValues?.[filterName];
+  if (!Array.isArray(defaults) || defaults.length === 0) {
+    return current.length > 0;
+  }
+  return JSON.stringify([...current].sort()) !== JSON.stringify([...defaults].sort());
+}
+
+/**
+ * @param {import('vue-router').LocationQuery} query
+ */
+export function routeQueryToSearchParams(query) {
+  const params = new URLSearchParams();
+  if (!query) return params;
+  for (const [key, raw] of Object.entries(query)) {
+    if (raw == null) continue;
+    if (Array.isArray(raw)) {
+      for (const value of raw) {
+        if (value != null) params.append(key, String(value));
+      }
+    } else {
+      params.set(key, String(raw));
+    }
+  }
+  return params;
+}
+
+/**
+ * @param {URLSearchParams} searchParams
+ */
+export function parseBrowseSearchParams(searchParams) {
+  /** @type {Record<string, unknown>} */
+  const filterValues = {};
+
+  for (const [param, filterName] of Object.entries(PARAM_TO_ARRAY_FILTER)) {
+    const values = splitComma(searchParams.get(param));
+    if (values.length > 0) {
+      filterValues[filterName] = values;
+    }
+  }
+
+  for (const [param, filterName] of Object.entries(PARAM_TO_RANGE_FILTER)) {
+    const range = parseRange(searchParams.get(param));
+    if (range) {
+      filterValues[filterName] = range;
+    }
+  }
+
+  const sortSlug = searchParams.get("sort")?.trim() ?? "";
+  const sort = SLUG_TO_SORT[sortSlug] || DEFAULT_SORT;
+  const q = searchParams.get("q")?.trim() ?? "";
+  const zip = searchParams.get("zip")?.trim() ?? "";
+  const loc = searchParams.get("loc")?.trim() ?? "";
+
+  return {
+    q,
+    sort,
+    zip,
+    loc,
+    filterValues,
+  };
+}
+
+/**
+ * @param {{
+ *   q?: string
+ *   sort?: string
+ *   zip?: string
+ *   loc?: string
+ *   filterValues?: Record<string, unknown>
+ * }} snapshot
+ * @param {Array<{ name: string, range?: boolean, min?: number, max?: number }>} filters
+ * @param {Record<string, unknown>} defaultFilterValues
+ */
+export function serializeBrowseSearchParams(snapshot, filters, defaultFilterValues) {
+  const params = new URLSearchParams();
+  const filterValues = snapshot.filterValues || {};
+  const filterByName = Object.fromEntries((filters || []).map((f) => [f.name, f]));
+
+  for (const [filterName, param] of Object.entries(ARRAY_FILTER_PARAM)) {
+    const value = filterValues[filterName];
+    if (!isArrayActive(defaultFilterValues, filterName, value)) continue;
+    const values = Array.isArray(value) ? value : [];
+    if (values.length > 0) {
+      params.set(param, values.join(","));
+    }
+  }
+
+  for (const [filterName, param] of Object.entries(RANGE_FILTER_PARAM)) {
+    const value = filterValues[filterName];
+    const filter = filterByName[filterName];
+    if (!isRangeActive(filter, value)) continue;
+    const encoded = formatRange(value);
+    if (encoded) params.set(param, encoded);
+  }
+
+  const sort = snapshot.sort || DEFAULT_SORT;
+  if (sort !== DEFAULT_SORT && SORT_TO_SLUG[sort]) {
+    params.set("sort", SORT_TO_SLUG[sort]);
+  }
+
+  const q = (snapshot.q || "").trim();
+  if (q) params.set("q", q);
+
+  const zip = (snapshot.zip || "").trim();
+  if (zip) params.set("zip", zip);
+
+  const loc = (snapshot.loc || "").trim();
+  if (loc) params.set("loc", loc);
+
+  return params.toString();
+}
+
+/** @param {string} queryString */
+export function queryStringToRouteQuery(queryString) {
+  if (!queryString) return {};
+  return Object.fromEntries(new URLSearchParams(queryString));
+}
+
+function normalizeRouteQuery(query) {
+  const params = routeQueryToSearchParams(query);
+  return params.toString();
+}
+
+/**
+ * @param {import('vue-router').LocationQuery} a
+ * @param {import('vue-router').LocationQuery} b
+ */
+export function browseRouteQueriesMatch(a, b) {
+  return normalizeRouteQuery(a) === normalizeRouteQuery(b);
+}
+
+export function floweringMonthLabel(index) {
+  return FLOWERING_MONTHS[index] ?? String(index);
+}
+
+export { DEFAULT_SORT, SORT_TO_SLUG, SLUG_TO_SORT, FLOWERING_MONTHS };


### PR DESCRIPTION
## Summary
- Add shareable browse URLs that serialize search, sort, filters, zip, and location into query params so filtered views can be bookmarked and shared
- Add an accessible plant detail dialog with loading/error states, prev/next navigation within browse results, keyboard and touch support, and preserved browse URL state when opening plants

## Test plan
- [ ] Open `/` with filters applied and confirm the URL updates as you change search, sort, filters, and location
- [ ] Copy the URL, open in a new tab, and confirm browse state restores correctly
- [ ] Click a plant tile and confirm detail opens in a modal with position label
- [ ] Use prev/next buttons, arrow keys, and swipe gestures to move between plants in the current result set
- [ ] Close detail and confirm browse filters remain in the URL
- [ ] Open a direct `/plants/:name` link with query params and confirm detail and browse state load correctly
- [ ] Verify Escape closes the dialog and focus returns to the triggering element
