### PR TITLE
Add configurable plant table view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ PAC_API_KEY={Ask us on codeforphilly slack channel #choose-native-plants-pa}
 # -----------------------------------------------------------------------------
 # These are the same for both Docker and Local modes
 AWS_ACCESS_KEY_ID={Ask us on codeforphilly slack channel #choose-native-plants-pa}
-AWS_SECRET_ACCESS_KEY{Ask us on codeforphilly slack channel #choose-native-plants-pa}
+AWS_SECRET_ACCESS_KEY={Ask us on codeforphilly slack channel #choose-native-plants-pa}
 AWS_DEFAULT_REGION=us-east-1
 LINODE_BUCKET_NAME=choose-native-plants
 LINODE_ENDPOINT_URL=https://us-east-1.linodeobjects.com

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,9 @@ module.exports = {
       files: ['*.vue'],
       parser: 'vue-eslint-parser',
       parserOptions: {
-        parser: 'babel-eslint',
+        // Vue files include <script setup lang="ts"> blocks, so their inner
+        // scripts need a TypeScript-aware parser.
+        parser: '@typescript-eslint/parser',
         ecmaVersion: 2021,
         sourceType: 'module'
       },
@@ -51,4 +53,3 @@ module.exports = {
     }
   ]
 };
-

--- a/README.md
+++ b/README.md
@@ -1,534 +1,161 @@
-# Choose Native Plants 🌱
+# Choose Native Plants
 
-<div align="center">
+[Choose Native Plants](https://choose-native-plants.com) helps US residents find native plants for their gardens and locate nearby nurseries that sell them.
 
-![GitHub license](https://img.shields.io/github/license/CodeForPhilly/pa-wildflower-selector)
-![GitHub stars](https://img.shields.io/github/stars/CodeForPhilly/pa-wildflower-selector)
-![GitHub issues](https://img.shields.io/github/issues/CodeForPhilly/pa-wildflower-selector)
+![Application screenshot](app-screenshot.png)
 
-**Help US residents find and source native plants for their gardens**
+## What it does
 
-[Getting Started](#getting-started) •
-[Development Modes](#development-modes) •
-[Features](#features) •
-[Architecture](#architecture) •
-[Development](#development) •
-[Database](#database-operations) •
-[Contributing](#contributing)
+- Searches and filters plants by growing conditions and ecological value
+- Shows plant details, native range, and local availability
+- Includes a garden planner and favorites
+- Supports desktop and mobile browsers
 
-</div>
+The app uses Vue 3, Node.js/Express, and MongoDB. Plant data originates in shared Google Sheets, images live in Linode Object Storage, and nursery availability comes from Plant Agents.
 
-## 🌟 Overview
-
-[Choose Native Plants](https://choose-native-plants.com) (formerly "PA Wildflower Selector") is a web application that helps US residents find native plants suitable for their gardens. Users can search and filter plants based on various criteria like sun exposure, soil moisture, pollinators attracted, and more. The app also shows where to buy these plants locally.
-
-<div align="center">
-<img src="app-screenshot.png" alt="Application Screenshot" width="600">
-</div>
-
-## ✨ Features
-
-- 🔍 Interactive plant search with multiple filter options
-- 🌿 Detailed plant information including growing conditions
-- 🏪 Local nursery finder showing where to buy plants
-- 🧙 Quick search wizard for beginner gardeners
-- 📱 Mobile-friendly responsive design
-
-## 🏗️ Architecture
-
-- **Frontend**: Vue.js web application
-- **Backend**: Node.js server
-- **Database**: MongoDB
-- **Data Source**: ERA via Google Sheets
-- **Vendor Integration**: PlantagentsAPI for local nursery data
-  - [API Documentation](https://app.plantagents.org/swagger/index.html)
-
-## 🚀 Getting Started
+## Local development
 
 ### Prerequisites
 
-- Git
-- User account with [Code for Philly](https://codeforphilly.org/)
+- Node.js 20 LTS (the version used by the Docker image)
+- MongoDB Community Server, running locally
+- [MongoDB Database Tools](https://www.mongodb.com/try/download/database-tools) (`mongorestore`)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), needed only to restore a database backup
+- Access to the project's shared environment values
 
-**For Docker Mode:**
-- Docker Desktop installed and running
+`mongosh` is useful for inspecting the database but is not required to run the app.
 
-**For Local Mode:**
-- Node.js installed
-- MongoDB Server Community Edition installed and running locally
-- MongoDB Shell (mongosh) installed
-- MongoDB Database Tools installed (required for `mongorestore` command used in database sync)
-- AWS CLI installed (required for syncing database from Linode)
-
-### Initial Setup
+### First-time setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/CodeForPhilly/pa-wildflower-selector
-
-# Navigate to project directory
 cd pa-wildflower-selector
-
-# Copy environment file
+npm ci
 cp .env.example .env
-# Edit .env with your configuration (see Development Modes section below)
 ```
 
-Choose your development mode:
-- **[Docker Mode](#docker-mode-quick-start)** - Recommended for beginners, uses Docker containers
-- **[Local Mode](#local-mode-quick-start)** - For development without Docker
+Ask in the Code for Philly `#choose-native-plants-pa` Slack channel for the private values, then edit `.env` for native local development:
 
-## 🔀 Development Modes
-
-This project supports two development modes: **Docker** and **Local**. Choose the mode that best fits your workflow.
-
-| Feature | Docker Mode | Local Mode |
-|---------|-------------|------------|
-| **MongoDB** | Runs in Docker container | Must be installed locally |
-| **Setup Complexity** | Simple (Docker handles everything) | Requires local MongoDB setup |
-| **Performance** | Slightly slower (container overhead) | Faster (direct execution) |
-| **Best For** | Beginners, consistent environments | Advanced developers, faster iteration |
-| **DB_HOST** | `mongodb` | `localhost` |
-
-### Prerequisites by Mode
-
-#### Docker Mode Prerequisites
-- ✅ Docker Desktop installed and running
-- ✅ `.env` file configured with Docker-specific values
-- ❌ No local MongoDB installation needed
-
-#### Local Mode Prerequisites
-- ✅ Node.js installed
-- ✅ MongoDB Server Community Edition installed and running locally
-- ✅ MongoDB Shell (mongosh) installed
-- ✅ MongoDB Database Tools installed (required for `mongorestore` command used in database sync) - [Download here](https://www.mongodb.com/try/download/database-tools)
-- ✅ AWS CLI installed (required for syncing database from Linode)
-- ✅ `.env` file configured with local-specific values
-
-### Environment Variables Setup
-
-The key difference between Docker and Local modes is the `DB_HOST` environment variable in your `.env` file.
-
-#### Required Environment Variables
-
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `DB_HOST` | MongoDB host address | ✅ Yes |
-| `DB_PORT` | MongoDB port (usually 27017) | ✅ Yes |
-| `DB_NAME` | Database name | ✅ Yes |
-| `DB_USER` | MongoDB username (if auth enabled) | ⚠️ Optional |
-| `DB_PASSWORD` | MongoDB password (if auth enabled) | ⚠️ Optional |
-| `PORT` | Node.js server port | ✅ Yes |
-| `MASTER_CSV_URL` | Google Sheets CSV URL | ✅ Yes |
-| `ARTICLES_CSV_URL` | Articles CSV URL | ✅ Yes |
-| `LOCAL_MAP_CSV_URL` | Local map CSV URL | ✅ Yes |
-| `ONLINE_STORES_CSV_URL` | Online stores CSV URL | ✅ Yes |
-| `PAC_API_BASE_URL` | Plant Agents API base URL | ✅ Yes |
-| `PAC_API_KEY` | Plant Agents API key | ✅ Yes |
-
-#### Environment Variable Differences
-
-| Variable | Docker Mode | Local Mode | Notes |
-|----------|------------|------------|-------|
-| `DB_HOST` | `mongodb` | `localhost` | Docker service name vs localhost |
-| `DB_PORT` | `27017` (internal) | `27017` | Usually same, but check docker-compose |
-| `PORT` | Set in docker-compose | `3000` or custom | Application port |
-| `MONGODB_LOCAL_PORT` | `7017` (host mapping) | Not used | Docker port mapping |
-| `NODE_LOCAL_PORT` | `6868` (host mapping) | Not used | Docker port mapping |
-
-### Docker Mode Quick Start
-
-1. **Prerequisites Check**
-   ```bash
-   # Verify Docker is running
-   docker --version
-   docker compose version
-   ```
-
-2. **Configure Environment**
-   ```bash
-   # Copy .env.example to .env if not already done
-   cp .env.example .env
-   
-   # Edit .env and ensure:
-   # DB_HOST=mongodb
-   # (Other Docker-specific values should already be set)
-   ```
-
-3. **Start Docker Containers**
-   ```bash
-   npm run docker:up
-   # Or: docker compose up -d --build
-   ```
-
-4. **Verify Setup**
-   ```bash
-   # Check containers are running
-   docker compose ps
-   
-   # Check MongoDB connection
-   node scripts/check-mongodb.js
-   ```
-
-5. **View Application**
-   - Visit http://localhost:6868/
-
-### Local Mode Quick Start
-
-1. **Prerequisites Check**
-   ```bash
-   # Verify Node.js is installed
-   node --version
-   npm --version
-   
-   # Verify MongoDB Server is installed
-   mongod --version
-   
-   # Verify MongoDB Shell is installed
-   mongosh --version
-   
-   # Verify MongoDB service is running
-   # Windows: Check Services panel or run: net start MongoDB
-   # macOS: brew services list | grep mongodb
-   # Linux: sudo systemctl status mongod
-   ```
-
-2. **Install MongoDB** (if not installed)
-   
-   **⚠️ Important:** You need to install **two separate components**:
-   - **MongoDB Server Community Edition** (`mongod`) - The database server
-   - **MongoDB Shell** (`mongosh`) - The command-line interface to interact with MongoDB
-   
-   **Windows:**
-   
-   **MongoDB Server Community Edition:**
-   - Download from [MongoDB Community Server](https://www.mongodb.com/try/download/community)
-   - Run the MSI installer and choose "Complete" installation
-   - During installation, choose "Install MongoDB as a Service" to run automatically
-   - Add MongoDB bin directory to your PATH (usually `C:\Program Files\MongoDB\Server\<version>\bin`)
-   - Verify: Open Services (`services.msc`) and check "MongoDB" service is running
-   - Or start manually: `net start MongoDB`
-   
-   **MongoDB Shell (mongosh):**
-   - Download from [MongoDB Shell Install](https://www.mongodb.com/try/download/shell)
-   - Run the MSI installer
-   - The installer will automatically add mongosh to your PATH
-   - Verify installation: `mongosh --version`
-   
-   **macOS:**
-   ```bash
-   # Using Homebrew
-   brew tap mongodb/brew
-   
-   # Install MongoDB Server Community Edition
-   brew install mongodb-community
-   brew services start mongodb-community
-   
-   # Install MongoDB Shell
-   brew install mongosh
-   ```
-   
-   **Linux:**
-   ```bash
-   # Ubuntu/Debian
-   # Install MongoDB Server Community Edition
-   sudo apt-get install mongodb
-   sudo systemctl start mongod
-   sudo systemctl enable mongod
-   
-   # Install MongoDB Shell
-   # Follow instructions at: https://www.mongodb.com/docs/mongodb-shell/install/
-   ```
-
-   **Install AWS CLI** (required for syncing database from Linode):
-   
-   For detailed installation instructions, see the [official AWS CLI installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
-   
-   **Windows:**
-   - Using Chocolatey: `choco install awscli`
-   - Or download MSI installer from the [AWS CLI installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-   
-   **macOS:**
-   ```bash
-   brew install awscli
-   ```
-   Or follow the [macOS installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-   
-   **Linux:**
-   ```bash
-   # Ubuntu/Debian
-   sudo apt-get install awscli
-   ```
-   Or follow the [Linux installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-   
-   **Verify AWS CLI Installation:**
-   ```bash
-   aws --version
-   ```
-   
-   **Note:** AWS CLI credentials are configured via environment variables in your `.env` file:
-   - `AWS_ACCESS_KEY_ID`
-   - `AWS_SECRET_ACCESS_KEY`
-   - `LINODE_BUCKET_NAME`
-   - `LINODE_ENDPOINT_URL` (optional, defaults to `https://us-east-1.linodeobjects.com`)
-
-3. **Verify MongoDB Installation**
-   ```bash
-   # Verify MongoDB Server is installed
-   mongod --version
-   
-   # Verify MongoDB Shell is installed
-   mongosh --version
-   
-   # Try connecting to MongoDB
-   mongosh
-   # Should connect to: mongodb://localhost:27017
-   ```
-
-4. **Configure Environment**
-   ```bash
-   # Copy .env.example to .env if not already done
-   cp .env.example .env
-   
-   # Edit .env and change:
-   # DB_HOST=localhost  (change from 'mongodb')
-   # PORT=3000  (or your preferred port)
-   ```
-
-5. **Install Dependencies**
-   ```bash
-   npm install
-   ```
-
-6. **Run Development Setup Check**
-   ```bash
-   npm run predev:local
-   # This will verify MongoDB connection and environment
-   ```
-
-7. **Start Development Server**
-   ```bash
-   npm run dev:local
-   # This runs both Vue dev server and Node.js server
-   ```
-
-8. **View Application**
-   - Vue dev server: http://localhost:8080/ (or configured port)
-   - Node.js API: http://localhost:3000/ (or configured PORT)
-
-### Switching Between Docker and Local Development
-
-#### Switching from Docker to Local Mode
-
-1. **Stop Docker Containers**
-   ```bash
-   npm run docker:down
-   # Or: docker compose down
-   ```
-
-2. **Update `.env` File**
-   ```bash
-   # Change these values:
-   DB_HOST=localhost  # was: mongodb
-   # Remove or comment out Docker-specific port mappings if desired
-   ```
-
-3. **Verify MongoDB is Running Locally**
-   ```bash
-   # Check MongoDB service
-   # Windows: services.msc or "net start MongoDB"
-   # macOS: brew services list
-   # Linux: sudo systemctl status mongod
-   
-   # Test connection
-   node scripts/check-mongodb.js
-   ```
-
-4. **Start Local Development**
-   ```bash
-   npm run dev:local
-   ```
-
-#### Switching from Local to Docker Mode
-
-1. **Stop Local Development Server**
-   - Press `Ctrl+C` to stop `npm run dev:local`
-
-2. **Update `.env` File**
-   ```bash
-   # Change these values:
-   DB_HOST=mongodb  # was: localhost
-   # Ensure Docker port mappings are set correctly
-   ```
-
-3. **Start Docker Containers**
-   ```bash
-   npm run docker:up
-   ```
-
-4. **Verify Setup**
-   ```bash
-   docker compose ps
-   node scripts/check-mongodb.js
-   ```
-
-### Sync Images (Both Modes)
-
-#### Docker Mode
-```bash
-docker compose exec app npm run sync-images
+```dotenv
+DB_HOST=localhost
+DB_PORT=27017
+PORT=8080
 ```
 
-#### Local Mode
+If your local MongoDB does not use authentication, leave `MONGODB_USER` and `MONGODB_PASSWORD` blank. Keep all real credentials in `.env`; it is ignored by Git.
+
+Download the image library:
+
 ```bash
 npm run sync-images
-# Images will be stored in ./images directory
 ```
 
-### Update Database (Both Modes)
+This command uses the project's AWS SDK and does not require the AWS CLI. It downloads into the ignored `images/` directory and safely skips files that are already current.
 
-To update your local MongoDB with the latest changes from the Google Sheets:
+Restore the latest shared database backup:
 
-#### Docker Mode
 ```bash
-docker compose exec app npm run fast-update-data
+npm run sync:down:db
 ```
 
-#### Local Mode
+Database restore requires both `aws` and `mongorestore` to be available on `PATH`. MongoDB does not support every cross-version dump/restore combination; use a server version compatible with the backup when `mongorestore` reports a version warning.
+
+Check the setup and start both servers:
+
 ```bash
-npm run fast-update-data
+npm run dev:local
 ```
 
-### Sync Database from Linode (Local Mode)
+Open [http://localhost:8080](http://localhost:8080). The Vue development server runs on port 8080 and proxies API and image requests to Express on port 3000.
 
-To sync your local database with the latest backup from Linode Object Storage:
+The first backend start may take a few minutes while missing plant embeddings are generated. Later starts should be quick.
 
-**Prerequisites:**
-- AWS CLI must be installed (see Local Mode Prerequisites above)
-- MongoDB Database Tools must be installed (includes `mongorestore` command) - [Download here](https://www.mongodb.com/try/download/database-tools)
-- Environment variables configured in `.env`:
-  - `AWS_ACCESS_KEY_ID`
-  - `AWS_SECRET_ACCESS_KEY`
-  - `LINODE_BUCKET_NAME`
-  - `LINODE_ENDPOINT_URL` (optional)
+## Docker
 
-**Sync Command:**
+Docker remains available for a containerized environment:
+
 ```bash
-npm run sync:down
+cp .env.example .env
+# Set DB_HOST=mongodb and add the private values.
+npm run docker:up
 ```
 
-This script will:
-1. List available database backups from Linode Object Storage
-2. Download the latest backup
-3. Restore it to your local MongoDB instance using `mongorestore`
+Open [http://localhost:6868](http://localhost:6868), or the value configured by `NODE_LOCAL_PORT`.
 
-**Note:** This is primarily useful for Local Mode development. Docker Mode typically uses the production database or creates its own test data.
-
-## 💾 Database Operations
-
-### MongoDB Connection
-
-#### Docker Mode
-Connect to MongoDB using MongoDB Compass with:
+```bash
+npm run docker:down
 ```
-mongodb://[username]:[password]@localhost:7017/pa-wildflower-selector?authSource=admin
-```
-(Replace `[username]` and `[password]` with values from your `.env` file)
 
-#### Local Mode
-Connect to MongoDB using MongoDB Compass with:
-```
-mongodb://[username]:[password]@localhost:27017/pa-wildflower-selector?authSource=admin
-```
-(Replace `[username]` and `[password]` with values from your `.env` file, or omit if authentication is disabled)
+The Compose stack pins MongoDB 5.0.6. Local development is often more convenient when working directly with sync and database tools.
 
-## 🛠️ Development
+## Useful commands
 
-### Available Scripts
+| Command | Purpose |
+| --- | --- |
+| `npm run dev:local` | Validate local setup and run client + server |
+| `npm run dev:client` | Run only the Vue client |
+| `npm run dev:server` | Run only Express on port 3000 |
+| `npm run sync-images` | Download Linode images |
+| `npm run sync:down:db` | Download and restore the latest database backup |
+| `npm run fast-update-data` | Refresh plant data from the source sheets |
+| `npm run lint` | Run lint checks |
+| `npm run build` | Build SSR and browser bundles |
+| `npm run docker:up` | Build and start the Compose stack |
+| `npm run docker:down` | Stop the Compose stack |
 
-#### Docker Scripts
-- `npm run docker:up` - Start Docker containers
-- `npm run docker:down` - Stop Docker containers
+Run `npm run` to see the complete script list, including schema, index, embedding, and upload utilities.
 
-#### Local Development Scripts
-- `npm run dev:local` - Run both Vue dev server and Node.js server (recommended)
-- `npm run dev:client` - Run Vue dev server only
-- `npm run dev:server` - Run Node.js server only
-- `npm run dev:full` - Run both servers concurrently (alternative to dev:local)
+## Environment and ports
 
-#### Build Scripts (used by Dockerfile - do not modify)
-- `npm run build` - Build for production (SSR + browser)
-- `npm run build-ssr` - Build SSR bundle
-- `npm run build-browser` - Build browser bundle
+| Setting | Native local | Docker |
+| --- | --- | --- |
+| `DB_HOST` | `localhost` | `mongodb` |
+| `DB_PORT` | `27017` | `27017` |
+| Browser URL | `http://localhost:8080` | `http://localhost:6868` |
+| Express port | `3000` | Value of `PORT` |
+| MongoDB host port | `27017` | Value of `MONGODB_LOCAL_PORT` |
 
-#### Utility Scripts
-- `npm run check-mongodb` - Verify MongoDB connection (via scripts/check-mongodb.js)
-- `npm run predev:local` - Run development environment checks before starting local dev
+Never commit `.env`, downloaded images, database backups, or `node_modules`. They are already covered by `.gitignore`.
 
-### Studio plant images (dev-only)
+## Troubleshooting
 
-This repo includes a small **dev-only** pipeline to generate “studio” plant images (single plant, side view, white background) from photos in `images/`.
+### MongoDB check fails
 
-- Script: `scripts/studio_images/generate_studio_images.py`
-- Installs: `pip install -r scripts/studio_images/requirements.txt`
-- Runs: `python scripts/studio_images/generate_studio_images.py --input-dir images --output-dir images/studio_full`
+- Confirm the MongoDB service is running.
+- Confirm `DB_HOST=localhost` and `DB_PORT` matches the local service.
+- If authentication is disabled locally, clear `MONGODB_USER` and `MONGODB_PASSWORD`.
+- Run `node scripts/check-mongodb.js` for a focused connection check.
 
-See `scripts/studio_images/README.md` for details.
+### Client loads but data requests fail
 
-### Project Structure
+- Confirm Express is listening on port 3000.
+- Do not give the local client and server the same port.
+- Use `npm run dev:local`; its scripts reserve 8080 for Vue and 3000 for Express.
 
-- **UI Code**: Located in `src/` directory
-- **Server Code**: Located in the main project directory (`lib/`, `app.js`)
-- **Scripts**: Helper scripts in `scripts/` directory
-- **Configuration**: `.env` file (copy from `.env.example`)
+### Sync command is missing a program
 
-### Troubleshooting
+- Image sync needs Node.js and the `.env` Linode values.
+- Database sync additionally needs AWS CLI and MongoDB Database Tools on `PATH`.
+- Restart the terminal after installing Windows packages so its `PATH` refreshes.
 
-#### MongoDB Connection Issues
+## Project layout
 
-**Docker Mode:**
-- Ensure Docker containers are running: `docker compose ps`
-- Check MongoDB container logs: `docker compose logs mongodb`
-- Verify `.env` has `DB_HOST=mongodb`
+- `src/` — Vue application
+- `app.js`, `lib/` — Express server and database access
+- `scripts/` — sync, migration, indexing, embedding, and maintenance tools
+- `public/` — static assets bundled with the app
+- `images/` — downloaded plant images; ignored by Git
+- `helm-chart/`, `deployment/` — deployment configuration
 
-**Local Mode:**
-- Verify MongoDB Server is installed: `mongod --version`
-- Verify MongoDB Shell is installed: `mongosh --version`
-- Verify MongoDB Server is running:
-  - Windows: Check Services panel or run `net start MongoDB`
-  - macOS: `brew services list` or `brew services start mongodb-community`
-  - Linux: `sudo systemctl status mongod` or `sudo systemctl start mongod`
-- Test connection: `mongosh` or `node scripts/check-mongodb.js`
-- Verify `.env` has `DB_HOST=localhost`
-- **Note:** If `mongosh` command is not found, you need to install MongoDB Shell separately (see Installation section above)
+The development-only studio image pipeline is documented in [`scripts/studio_images/README.md`](scripts/studio_images/README.md).
 
-#### Port Conflicts
+## Contributing
 
-- If ports are already in use, update `PORT` in `.env` (Local mode) or port mappings in `docker-compose.yml` (Docker mode)
-- Check what's using the port:
-  - Windows: `netstat -ano | findstr :PORT`
-  - macOS/Linux: `lsof -i :PORT`
+1. Create a feature branch.
+2. Make and verify a focused change.
+3. Commit and push the branch.
+4. Open a pull request.
 
-#### Environment Variable Issues
+Questions are welcome in the Code for Philly project channel or at [contact@choosenativeplants.com](mailto:contact@choosenativeplants.com).
 
-- Ensure `.env` file exists (copy from `.env.example`)
-- Verify all required variables are set (see Environment Variables Setup section)
-- Check that `DB_HOST` matches your mode (`mongodb` for Docker, `localhost` for Local)
-
-## 👥 Contributing
-
-We welcome contributions from the community! To contribute:
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 📧 Contact
-
-For any questions or inquiries, please email us at [contact@choosenativeplants.com](mailto:contact@choosenativeplants.com).
-
-## 📄 License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the [MIT License](LICENSE).

--- a/download.js
+++ b/download.js
@@ -4,9 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 const parse = require('csv-parse/lib/sync');
-const qs = require('qs');
 const db = require('./lib/db');
-const { RateLimiter } = require('limiter');
 // Logging function
 function log(message) {
     const timestamp = new Date().toISOString();
@@ -75,14 +73,9 @@ async function go() {
 }
 
 async function downloadMain() {
-    const limiter = new RateLimiter({ tokensPerInterval: 1, interval: "second" });
-
     log('Fetching spreadsheet data...');
     const body = await get(process.env.MASTER_CSV_URL);
     const articlesBody = await get(process.env.ARTICLES_CSV_URL);
-
-    // Initialize empty rowsByName object
-    let rowsByName = {};
 
     // Parse master CSV
     const records = parse(body, {
@@ -191,7 +184,6 @@ async function updateNurseries() {
 
     // Insert nurseries into database
     for (const record of records) {
-        const address = `${record.ADDRESS} ${record.CITY}, ${record.STATE} ${record.ZIP}`;
         record.lon = parseFloat(record.Long);
         record.lat = parseFloat(record.Lat);
         await nurseries.insertOne(record);
@@ -261,7 +253,7 @@ async function update(plants, clean) {
     }
 }
 
-async function get(url, type = 'text', tries = 1) {
+async function get(url, type = 'text') {
     let lastError;
     for (let attempt = 0; attempt < 5; attempt++) {
         try {
@@ -283,7 +275,7 @@ async function get(url, type = 'text', tries = 1) {
 }
 
 function pause() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         setTimeout(resolve, 5000);
     });
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,7 +66,9 @@ const axios = require("axios");
 // const cache = {};
 
 module.exports = async function ({ plants, nurseries }) {
-  const port = process.env.PORT || 3000;
+  // Local development uses SERVER_PORT so Vue can keep PORT for its dev server.
+  // Production and Docker continue to use PORT.
+  const port = process.env.SERVER_PORT || process.env.PORT || 3000;
   const app = express();
   const publicDir = `${__dirname}/../public`;
   if (!fs.existsSync(publicDir)) {

--- a/massage.js
+++ b/massage.js
@@ -1,8 +1,6 @@
 require('dotenv').config();
 const db = require('./lib/db');
 const fs = require('fs');
-const path = require('path');
-const { match } = require('assert');
 
 function isFiniteNumber(n) {
   return typeof n === 'number' && Number.isFinite(n);

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@playwright/test": "^1.40.0",
         "@types/node": "^20.0.0",
         "@types/three": "^0.182.0",
+        "@typescript-eslint/parser": "^5.62.0",
         "@vue/cli-plugin-typescript": "^4.5.19",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
@@ -4097,12 +4098,50 @@
         "node": ">=1.0.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -5328,6 +5367,325 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
@@ -5792,19 +6150,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/@vue/cli-plugin-typescript/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@vue/cli-plugin-typescript/node_modules/to-regex-range": {
@@ -6656,18 +7001,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/aproba": {
@@ -11462,6 +11795,16 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -13102,18 +13445,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/http-proxy-middleware/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/http-proxy-middleware/node_modules/to-regex-range": {
@@ -16933,6 +17264,18 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -17933,6 +18276,27 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -18042,19 +18406,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -18474,6 +18825,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -18561,6 +18923,30 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/run-queue": {
@@ -20932,19 +21318,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/ts-loader/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/ts-loader/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "predev:local": "node scripts/dev-setup.js",
     "dev:local": "npm run predev:local && concurrently --names \"SERVER,CLIENT\" --prefix-colors \"blue,green\" \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "vue-cli-service serve",
-    "dev:server": "cross-env NODE_ENV=development node app.js",
+    "dev:server": "cross-env NODE_ENV=development SERVER_PORT=3000 node app.js",
     "dev:full": "concurrently --names \"SERVER,CLIENT\" --prefix-colors \"blue,green\" \"npm run dev:server\" \"npm run dev:client\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@playwright/test": "^1.40.0",
     "@types/node": "^20.0.0",
     "@types/three": "^0.182.0",
+    "@typescript-eslint/parser": "^5.62.0",
     "@vue/cli-plugin-typescript": "^4.5.19",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",

--- a/scripts/sync-images.js
+++ b/scripts/sync-images.js
@@ -9,8 +9,12 @@
 require("dotenv").config();
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
-const os = require("os");
+const { pipeline } = require("stream/promises");
+const {
+  S3Client,
+  ListObjectsV2Command,
+  GetObjectCommand
+} = require("@aws-sdk/client-s3");
 
 // Load environment variables
 const {
@@ -46,29 +50,73 @@ async function syncImages() {
       console.log(`📁 Created images directory: ${imagesDir}\n`);
     }
 
+    const endpoint = new URL(LINODE_ENDPOINT_URL);
+    const regionMatch = endpoint.hostname.match(/^([a-z0-9-]+)\.linodeobjects\.com$/);
+    const s3 = new S3Client({
+      endpoint: LINODE_ENDPOINT_URL,
+      region: regionMatch ? regionMatch[1] : (process.env.AWS_DEFAULT_REGION || 'us-east-1'),
+      credentials: {
+        accessKeyId: AWS_ACCESS_KEY_ID,
+        secretAccessKey: AWS_SECRET_ACCESS_KEY
+      }
+    });
+
     // Sync images from Linode bucket
     console.log('🔄 Syncing images from Linode Object Storage...');
-    const syncCommand = `aws s3 sync s3://${LINODE_BUCKET_NAME}/images/ "${imagesDir}/" --endpoint-url ${LINODE_ENDPOINT_URL}`;
-    
-    try {
-      execSync(syncCommand, {
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID,
-          AWS_SECRET_ACCESS_KEY
+
+    let continuationToken;
+    let downloaded = 0;
+    let skipped = 0;
+
+    do {
+      const page = await s3.send(new ListObjectsV2Command({
+        Bucket: LINODE_BUCKET_NAME,
+        Prefix: 'images/',
+        ContinuationToken: continuationToken
+      }));
+
+      for (const object of page.Contents || []) {
+        if (!object.Key || object.Key.endsWith('/')) {
+          continue;
         }
-      });
-      console.log(`\n✅ Images have been downloaded to ${imagesDir}/`);
-      console.log('===== Images Sync Process Completed =====\n');
-    } catch (error) {
-      console.error('\n❌ Failed to sync images');
-      console.error(`   Error: ${error.message}\n`);
-      console.error('💡 Make sure AWS CLI is installed and configured:');
-      console.error('   - Install: https://aws.amazon.com/cli/');
-      console.error('   - Or use: brew install awscli (macOS)');
-      console.error('   - Or use: choco install awscli (Windows)\n');
-      process.exit(1);
+
+        const relativePath = object.Key.slice('images/'.length);
+        const localPath = path.resolve(imagesDir, relativePath);
+        const imagesRoot = path.resolve(imagesDir) + path.sep;
+
+        if (!localPath.startsWith(imagesRoot)) {
+          throw new Error(`Unsafe object key: ${object.Key}`);
+        }
+
+        const existing = await fs.promises.stat(localPath).catch(() => null);
+        if (existing && existing.isFile() && existing.size === object.Size) {
+          skipped += 1;
+          continue;
+        }
+
+        await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+        const result = await s3.send(new GetObjectCommand({
+          Bucket: LINODE_BUCKET_NAME,
+          Key: object.Key
+        }));
+        const temporaryPath = `${localPath}.download`;
+
+        await pipeline(result.Body, fs.createWriteStream(temporaryPath));
+        await fs.promises.rename(temporaryPath, localPath);
+        downloaded += 1;
+      }
+
+      continuationToken = page.IsTruncated
+        ? page.NextContinuationToken
+        : undefined;
+    } while (continuationToken);
+
+    console.log(`\n✅ Images have been downloaded to ${imagesDir}/`);
+    console.log(`   Downloaded: ${downloaded}; already current: ${skipped}`);
+    console.log('===== Images Sync Process Completed =====\n');
+
+    if (typeof s3.destroy === 'function') {
+      s3.destroy();
     }
 
   } catch (error) {
@@ -79,7 +127,6 @@ async function syncImages() {
 }
 
 syncImages();
-
 
 
 

--- a/src/components/DesignIOEditor.vue
+++ b/src/components/DesignIOEditor.vue
@@ -294,5 +294,3 @@ const confirmAndImport = () => {
 </style>
 
 
-
-

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -261,7 +261,29 @@
               </div>
 
               <div class="favorites-photo-mode">
-                <div class="photo-mode-toggle" role="group" aria-label="Photos">
+                <div class="view-mode-toggle" role="group" aria-label="Results layout">
+                  <button
+                    type="button"
+                    class="view-mode-button"
+                    :class="{ active: viewMode === 'tiles' }"
+                    :aria-pressed="viewMode === 'tiles'"
+                    @click="setViewMode('tiles')"
+                  >
+                    <span class="material-icons" aria-hidden="true">grid_view</span>
+                    Tiles
+                  </button>
+                  <button
+                    type="button"
+                    class="view-mode-button"
+                    :class="{ active: viewMode === 'table' }"
+                    :aria-pressed="viewMode === 'table'"
+                    @click="setViewMode('table')"
+                  >
+                    <span class="material-icons" aria-hidden="true">view_list</span>
+                    Table
+                  </button>
+                </div>
+                <div v-if="viewMode === 'tiles'" class="photo-mode-toggle" role="group" aria-label="Photos">
                   <button
                     type="button"
                     class="photo-mode-button"
@@ -418,7 +440,29 @@
 
               <!-- Row 2: secondary mode -->
               <div class="browse-toolbar-row browse-toolbar-row--mode">
-                <div class="photo-mode-toggle" role="group" aria-label="Photos">
+                <div class="view-mode-toggle" role="group" aria-label="Results layout">
+                  <button
+                    type="button"
+                    class="view-mode-button"
+                    :class="{ active: viewMode === 'tiles' }"
+                    :aria-pressed="viewMode === 'tiles'"
+                    @click="setViewMode('tiles')"
+                  >
+                    <span class="material-icons" aria-hidden="true">grid_view</span>
+                    Tiles
+                  </button>
+                  <button
+                    type="button"
+                    class="view-mode-button"
+                    :class="{ active: viewMode === 'table' }"
+                    :aria-pressed="viewMode === 'table'"
+                    @click="setViewMode('table')"
+                  >
+                    <span class="material-icons" aria-hidden="true">view_list</span>
+                    Table
+                  </button>
+                </div>
+                <div v-if="viewMode === 'tiles'" class="photo-mode-toggle" role="group" aria-label="Photos">
                   <button
                     type="button"
                     class="photo-mode-button"
@@ -708,7 +752,7 @@
               Showing {{ results.length }} of {{ total }} plants
               <span v-if="nearDisplayLabel"> near {{ nearDisplayLabel }}</span>
             </p>
-            <article class="plants">
+            <article v-if="viewMode === 'tiles'" class="plants">
             <article
               v-for="result in results"
               :key="result._id"
@@ -776,14 +820,20 @@
               :key="extra.id"
               class="extra"
             ></article>
-            <!-- Infinite scroll sentinel: keep it anchored to the *results* column,
-                 not after <main> (desktop filters column can add large bottom space). -->
-            <div ref="next" class="infinite-scroll-sentinel" aria-hidden="true"></div>
-            <BrowseResultStates
-              v-if="showBrowseUpdating"
-              state="updating"
+            </article>
+            <PlantTable
+              v-else
+              :plants="results"
+              :favorites="$store.state.favorites"
+              :selected-columns="tableColumns"
+              @open-plant="openPlantFromTable"
+              @toggle-favorite="toggleFavorite"
+              @toggle-column="toggleTableColumn"
+              @reset-columns="resetTableColumns"
             />
-          </article>
+            <!-- Paging stays independent from the selected presentation. -->
+            <div ref="next" class="infinite-scroll-sentinel" aria-hidden="true"></div>
+            <BrowseResultStates v-if="showBrowseUpdating" state="updating" />
           </div>
         </div>
     </main>
@@ -811,6 +861,10 @@ import Menu from "./Menu.vue";
 import BulkAddFavoritesModal from "./BulkAddFavoritesModal.vue";
 import BrowseResultStates from "./BrowseResultStates.vue";
 import LocationSearchField from "./LocationSearchField.vue";
+import PlantTable, {
+  DEFAULT_PLANT_TABLE_COLUMNS,
+  PLANT_TABLE_COLUMNS,
+} from "./PlantTable.vue";
 import { Trash2 } from "lucide-vue-next";
 
 const twoUpImageCredits = [
@@ -856,6 +910,7 @@ export default {
     BulkAddFavoritesModal,
     BrowseResultStates,
     LocationSearchField,
+    PlantTable,
     Trash2,
   },
   props: {
@@ -1060,6 +1115,8 @@ export default {
       isLoadingLocation: false,
       q: "",
       activeSearch: "",
+      viewMode: "tiles",
+      tableColumns: [...DEFAULT_PLANT_TABLE_COLUMNS],
       sort: "Sort by Recommendation Score",
       previousSort: "Sort by Recommendation Score", // Store previous sort before Search Relevance
       filters,
@@ -1460,6 +1517,7 @@ export default {
     this.zipCode = localStorage.getItem("zipCode") || "";
     this.manualZip = localStorage.getItem("manualZip") === "true";
     this.filterValues["States"] = [localStorage.getItem("state")];
+    this.restoreTablePreferences();
 
     // Pre-set the default zip code to ensure immediate response
     if (!this.zipCode) {
@@ -2724,6 +2782,9 @@ export default {
       if (evt && typeof evt.preventDefault === "function") evt.preventDefault();
       this.$router.push(this.plantLink(result));
     },
+    openPlantFromTable(result) {
+      this.$router.push(this.plantLink(result));
+    },
     imageStyle(image, preview = true) {
       const url = this.imageUrl(image, preview);
       const isStudio = this.photoMode === "studio";
@@ -2826,6 +2887,43 @@ export default {
     },
     setPhotoMode(mode) {
       this.$store.commit("setPhotoMode", mode);
+    },
+    setViewMode(mode) {
+      if (!["tiles", "table"].includes(mode)) return;
+      this.viewMode = mode;
+      if (typeof window !== "undefined") {
+        localStorage.setItem("plantResultsView", mode);
+      }
+      this.$nextTick(() => {
+        this.teardownInfiniteScroll();
+        this.setupInfiniteScroll();
+      });
+    },
+    toggleTableColumn(key) {
+      if (!PLANT_TABLE_COLUMNS.some((column) => column.key === key)) return;
+      this.tableColumns = this.tableColumns.includes(key)
+        ? this.tableColumns.filter((columnKey) => columnKey !== key)
+        : [...this.tableColumns, key];
+      localStorage.setItem("plantTableColumns", JSON.stringify(this.tableColumns));
+    },
+    resetTableColumns() {
+      this.tableColumns = [...DEFAULT_PLANT_TABLE_COLUMNS];
+      localStorage.setItem("plantTableColumns", JSON.stringify(this.tableColumns));
+    },
+    restoreTablePreferences() {
+      const storedView = localStorage.getItem("plantResultsView");
+      if (["tiles", "table"].includes(storedView)) {
+        this.viewMode = storedView;
+      }
+      try {
+        const storedColumns = JSON.parse(localStorage.getItem("plantTableColumns") || "null");
+        const validKeys = new Set(PLANT_TABLE_COLUMNS.map((column) => column.key));
+        if (Array.isArray(storedColumns)) {
+          this.tableColumns = storedColumns.filter((key) => validKeys.has(key));
+        }
+      } catch (error) {
+        console.warn("Could not restore table columns:", error);
+      }
     },
     openFilters() {
       this.filtersOpen = true;
@@ -3377,9 +3475,6 @@ export default {
 
         this.total = data.total;
 
-        // If the sentinel is already in/near view (short result sets, or user at bottom),
-        // keep loading additional pages.
-        this.scheduleMaybeLoadMore("post-fetch");
       } catch (error) {
         if (this.activeFetchRequestId === requestId) {
           console.error("Error fetching plants:", error);
@@ -3390,6 +3485,21 @@ export default {
       } finally {
         if (this.activeFetchRequestId === requestId) {
           this.loading = false;
+          // The sentinel is rendered only after the loading state clears. On the
+          // initial request, setupInfiniteScroll() can run before it exists, so
+          // attach the observer/fallback now that the results DOM is available.
+          await this.$nextTick();
+          if (
+            !this.favorites &&
+            !this.infiniteObserver &&
+            !this.scrollFallbackHandler
+          ) {
+            this.setupInfiniteScroll();
+          } else {
+            // If the sentinel is already in/near view (short result sets, or the
+            // user is still at the bottom), keep loading additional pages.
+            this.scheduleMaybeLoadMore("post-fetch");
+          }
         }
       }
     },
@@ -4234,6 +4344,9 @@ button.text {
 
 .browse-toolbar-row--mode {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .browse-filter-button {
@@ -4332,8 +4445,7 @@ button.text {
   }
 
   /* Flatten the internal rows so we can place controls on a single grid row */
-  .browse-toolbar-row--actions,
-  .browse-toolbar-row--mode {
+  .browse-toolbar-row--actions {
     display: contents;
   }
 
@@ -4391,14 +4503,18 @@ button.text {
     display: none !important;
   }
 
-  .browse-toolbar-row--mode .photo-mode-toggle {
+  .browse-toolbar-row--mode {
     grid-area: mode;
     width: 100%;
     margin: 0;
+  }
+  .browse-toolbar-row--mode .photo-mode-toggle,
+  .browse-toolbar-row--mode .view-mode-toggle {
     max-width: none;
     min-width: 180px;
   }
-  .browse-toolbar-row--mode .photo-mode-button {
+  .browse-toolbar-row--mode .photo-mode-button,
+  .browse-toolbar-row--mode .view-mode-button {
     padding: 8px 8px;
     font-size: 13px;
     min-width: 0;
@@ -4427,7 +4543,8 @@ button.text {
   .browse-sort-button {
     padding: 10px 8px;
   }
-  .browse-toolbar-row--mode .photo-mode-button {
+  .browse-toolbar-row--mode .photo-mode-button,
+  .browse-toolbar-row--mode .view-mode-button {
     padding: 7px 6px;
     font-size: 12px;
   }
@@ -4496,6 +4613,51 @@ button.text {
   border-radius: 999px;
   overflow: hidden;
   background: #fcf9f4;
+}
+
+.view-mode-toggle {
+  display: flex;
+  width: 100%;
+  border: 1px solid rgba(29, 46, 38, 0.42);
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.view-mode-button {
+  display: inline-flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 8px 12px;
+  color: #42534b;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  font: 700 14px Roboto, sans-serif;
+  cursor: pointer;
+}
+
+.view-mode-button + .view-mode-button {
+  border-left: 1px solid rgba(29, 46, 38, 0.28);
+}
+
+.view-mode-button.active {
+  color: #fff;
+  background: #1d2e26;
+}
+
+.view-mode-button .material-icons {
+  font-size: 18px;
+}
+
+.view-mode-button:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 3px solid rgba(183, 77, 21, 0.38);
+  outline-offset: -3px;
 }
 
 .photo-mode-button {

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -1422,13 +1422,6 @@ export default {
       deep: true,
     },
   },
-  beforeDestroy() {
-    if (typeof window === "undefined" || typeof document === "undefined") return;
-    window.removeEventListener("keydown", this.onFiltersKeydown, true);
-    if (this._prevBodyOverflow !== undefined) {
-      document.body.style.overflow = this._prevBodyOverflow;
-    }
-  },
   // Server only
   async serverPrefetch() {
     try {
@@ -1549,6 +1542,12 @@ export default {
     this.setupInfiniteScroll();
   },
   beforeUnmount() {
+    if (typeof window !== "undefined" && typeof document !== "undefined") {
+      window.removeEventListener("keydown", this.onFiltersKeydown, true);
+      if (this._prevBodyOverflow !== undefined) {
+        document.body.style.overflow = this._prevBodyOverflow;
+      }
+    }
     this.teardownInfiniteScroll();
     if (this.submitTimeout) {
       clearTimeout(this.submitTimeout);

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -260,7 +260,10 @@
                 </div>
               </div>
 
-              <div class="favorites-photo-mode">
+              <div
+                class="favorites-photo-mode display-mode-controls"
+                :class="{ 'display-mode-controls--table': viewMode === 'table' }"
+              >
                 <div class="view-mode-toggle" role="group" aria-label="Results layout">
                   <button
                     type="button"
@@ -270,7 +273,7 @@
                     @click="setViewMode('tiles')"
                   >
                     <span class="material-icons" aria-hidden="true">grid_view</span>
-                    Tiles
+                    <span class="mode-label">Tiles</span>
                   </button>
                   <button
                     type="button"
@@ -280,7 +283,7 @@
                     @click="setViewMode('table')"
                   >
                     <span class="material-icons" aria-hidden="true">view_list</span>
-                    Table
+                    <span class="mode-label">Table</span>
                   </button>
                 </div>
                 <div v-if="viewMode === 'tiles'" class="photo-mode-toggle" role="group" aria-label="Photos">
@@ -291,7 +294,8 @@
                     @click="setPhotoMode('habitat')"
                     :aria-pressed="photoMode === 'habitat'"
                   >
-                    Habitat
+                    <span class="material-icons" aria-hidden="true">landscape</span>
+                    <span class="mode-label">Habitat</span>
                   </button>
                   <button
                     type="button"
@@ -300,7 +304,8 @@
                     @click="setPhotoMode('studio')"
                     :aria-pressed="photoMode === 'studio'"
                   >
-                    Studio
+                    <span class="material-icons" aria-hidden="true">filter_vintage</span>
+                    <span class="mode-label">Studio</span>
                   </button>
                 </div>
               </div>
@@ -439,7 +444,10 @@
               </div>
 
               <!-- Row 2: secondary mode -->
-              <div class="browse-toolbar-row browse-toolbar-row--mode">
+              <div
+                class="browse-toolbar-row browse-toolbar-row--mode display-mode-controls"
+                :class="{ 'display-mode-controls--table': viewMode === 'table' }"
+              >
                 <div class="view-mode-toggle" role="group" aria-label="Results layout">
                   <button
                     type="button"
@@ -449,7 +457,7 @@
                     @click="setViewMode('tiles')"
                   >
                     <span class="material-icons" aria-hidden="true">grid_view</span>
-                    Tiles
+                    <span class="mode-label">Tiles</span>
                   </button>
                   <button
                     type="button"
@@ -459,7 +467,7 @@
                     @click="setViewMode('table')"
                   >
                     <span class="material-icons" aria-hidden="true">view_list</span>
-                    Table
+                    <span class="mode-label">Table</span>
                   </button>
                 </div>
                 <div v-if="viewMode === 'tiles'" class="photo-mode-toggle" role="group" aria-label="Photos">
@@ -470,7 +478,8 @@
                     @click="setPhotoMode('habitat')"
                     :aria-pressed="photoMode === 'habitat'"
                   >
-                    Habitat
+                    <span class="material-icons" aria-hidden="true">landscape</span>
+                    <span class="mode-label">Habitat</span>
                   </button>
                   <button
                     type="button"
@@ -479,7 +488,8 @@
                     @click="setPhotoMode('studio')"
                     :aria-pressed="photoMode === 'studio'"
                   >
-                    Studio
+                    <span class="material-icons" aria-hidden="true">filter_vintage</span>
+                    <span class="mode-label">Studio</span>
                   </button>
                 </div>
               </div>
@@ -4344,9 +4354,6 @@ button.text {
 
 .browse-toolbar-row--mode {
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .browse-filter-button {
@@ -4511,7 +4518,7 @@ button.text {
   .browse-toolbar-row--mode .photo-mode-toggle,
   .browse-toolbar-row--mode .view-mode-toggle {
     max-width: none;
-    min-width: 180px;
+    min-width: 0;
   }
   .browse-toolbar-row--mode .photo-mode-button,
   .browse-toolbar-row--mode .view-mode-button {
@@ -4610,9 +4617,21 @@ button.text {
   display: flex;
   width: 100%;
   border: 1px solid #b74d15;
-  border-radius: 999px;
+  border-radius: 9px;
   overflow: hidden;
   background: #fcf9f4;
+}
+
+.display-mode-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.display-mode-controls--table {
+  grid-template-columns: minmax(160px, 220px);
 }
 
 .view-mode-toggle {
@@ -4630,13 +4649,14 @@ button.text {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  min-height: 40px;
-  padding: 8px 12px;
+  min-width: 0;
+  min-height: 36px;
+  padding: 5px 4px;
   color: #42534b;
   background: transparent;
   border: 0;
   border-radius: 0;
-  font: 700 14px Roboto, sans-serif;
+  font: 700 12px Roboto, sans-serif;
   cursor: pointer;
 }
 
@@ -4649,8 +4669,9 @@ button.text {
   background: #1d2e26;
 }
 
-.view-mode-button .material-icons {
-  font-size: 18px;
+.view-mode-button .material-icons,
+.photo-mode-button .material-icons {
+  font-size: 16px;
 }
 
 .view-mode-button:focus-visible {
@@ -4661,11 +4682,18 @@ button.text {
 }
 
 .photo-mode-button {
+  display: inline-flex;
   flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 0;
   border: none;
   border-radius: 0;
-  padding: 10px 12px;
-  font-size: 16px;
+  min-height: 36px;
+  padding: 5px 4px;
+  font-size: 12px;
+  font-weight: 700;
   font-family: Roboto;
   background: transparent;
   color: #b74d15;
@@ -4962,6 +4990,20 @@ th {
 .favorites-photo-mode {
   grid-area: toggle;
   min-width: 0;
+}
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  .display-mode-controls .mode-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 }
 
 .favorites-quick-add {

--- a/src/components/Garden3DView.vue
+++ b/src/components/Garden3DView.vue
@@ -2559,5 +2559,3 @@ const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(mi
   }
 }
 </style>
-
-

--- a/src/components/GardenPlanner.vue
+++ b/src/components/GardenPlanner.vue
@@ -18,8 +18,8 @@
         @undo="undo"
         @redo="redo"
         @clear="clearLayout"
-        @export="showDesignExport = true"
-        @import="showDesignImport = true"
+        @export="openDesignExport"
+        @import="openDesignImport"
         @toggle-summary="handleSummaryToggle"
         @toggle-3d="toggle3D"
         @fit-to-plants="handleGridSizeFit"
@@ -160,6 +160,7 @@ import DesignIOEditor from './DesignIOEditor.vue';
 import PlannerToolbar from './PlannerToolbar.vue';
 import type { PlacedPlant, Plant } from '../types/garden';
 import { GARDEN_DESIGN_SCHEMA, GARDEN_DESIGN_VERSION } from '../lib/gardenDesign';
+import { trackEvent } from '../lib/analytics';
 
 const Garden3DView = defineAsyncComponent({
   loader: () => {
@@ -242,11 +243,28 @@ const exportDesignText = computed(() => getExportDesignText());
 const handleImportDesign = (text: string) => {
   const result = importDesignFromText(text);
   if (!result.success) {
+    trackEvent('planner_design_import_failed');
     window.alert(result.error || 'Import failed.');
     return;
   }
+  trackEvent('planner_design_imported', {
+    placed_plant_count: placedPlants.value.length,
+    unique_species_count: new Set(placedPlants.value.map(p => p.plantId)).size,
+  });
   showDesignImport.value = false;
   showSummary.value = false;
+};
+
+const openDesignExport = () => {
+  showDesignExport.value = true;
+  trackEvent('planner_design_export_opened', {
+    placed_plant_count: placedPlants.value.length,
+  });
+};
+
+const openDesignImport = () => {
+  showDesignImport.value = true;
+  trackEvent('planner_design_import_opened');
 };
 
 const handlePaletteDragStart = (event: PointerEvent, plantId: string) => {
@@ -266,12 +284,14 @@ const handleSummaryToggle = () => {
     // Turning summary off: restore the last non-summary mode
     showSummary.value = false;
     show3D.value = lastNonSummary3D.value;
+    trackEvent('planner_view_changed', { planner_view: show3D.value ? '3d' : '2d' });
     return;
   }
   // Turning summary on: remember current mode and switch to summary (always exits 3D)
   lastNonSummary3D.value = show3D.value;
   show3D.value = false;
   showSummary.value = true;
+  trackEvent('planner_view_changed', { planner_view: 'summary' });
 };
 
 const toggle3D = () => {
@@ -279,6 +299,7 @@ const toggle3D = () => {
   showSummary.value = false;
   show3D.value = !show3D.value;
   lastNonSummary3D.value = show3D.value;
+  trackEvent('planner_view_changed', { planner_view: show3D.value ? '3d' : '2d' });
 };
 
 const cycleLabelMode = () => {

--- a/src/components/PlantTable.vue
+++ b/src/components/PlantTable.vue
@@ -1,0 +1,365 @@
+<template>
+  <section class="plant-table-section" aria-label="Plant results table">
+    <div class="table-options">
+      <p>Scroll sideways to compare more fields.</p>
+      <div class="column-picker">
+        <button
+          type="button"
+          class="column-picker-button"
+          aria-haspopup="true"
+          :aria-expanded="columnsOpen"
+          @click="columnsOpen = !columnsOpen"
+        >
+          <span class="material-icons" aria-hidden="true">view_column</span>
+          Columns
+        </button>
+        <div v-if="columnsOpen" class="column-picker-menu">
+          <div class="column-picker-heading">
+            <strong>Choose columns</strong>
+            <button type="button" class="column-reset" @click="$emit('reset-columns')">
+              Reset
+            </button>
+          </div>
+          <small>Names and favorites are always shown.</small>
+          <label v-for="column in optionalColumns" :key="column.key">
+            <input
+              type="checkbox"
+              :checked="selectedColumns.includes(column.key)"
+              @change="$emit('toggle-column', column.key)"
+            />
+            {{ column.label }}
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="plant-table-scroll" tabindex="0">
+      <table class="plant-table">
+        <thead>
+          <tr>
+            <th class="favorite-column"><span class="visually-hidden">Favorite</span></th>
+            <th class="common-name-column">Common name</th>
+            <th class="scientific-name-column">Scientific name</th>
+            <th v-for="column in visibleColumns" :key="column.key" :class="`${column.key}-column`">
+              {{ column.label }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="plant in plants" :key="plant._id">
+            <td class="favorite-column">
+              <button
+                type="button"
+                class="table-favorite"
+                :aria-label="
+                  isFavorite(plant._id)
+                    ? `Remove ${plant['Common Name']} from favorites`
+                    : `Add ${plant['Common Name']} to favorites`
+                "
+                @click="$emit('toggle-favorite', plant._id)"
+              >
+                <span class="material-icons" aria-hidden="true">
+                  {{ isFavorite(plant._id) ? "favorite" : "favorite_outline" }}
+                </span>
+              </button>
+            </td>
+            <td class="common-name-column">
+              <button type="button" class="plant-name-link" @click="$emit('open-plant', plant)">
+                {{ displayValue(plant["Common Name"]) }}
+              </button>
+            </td>
+            <td class="scientific-name-column">
+              <button
+                type="button"
+                class="plant-name-link scientific-name"
+                @click="$emit('open-plant', plant)"
+              >
+                {{ displayValue(plant["Scientific Name"]) }}
+              </button>
+            </td>
+            <td v-for="column in visibleColumns" :key="column.key" :class="`${column.key}-column`">
+              {{ formatColumnValue(plant, column) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<script>
+export const PLANT_TABLE_COLUMNS = [
+  { key: "height", label: "Height", fields: ["Height (feet)"], suffix: " ft" },
+  { key: "sun", label: "Sun", fields: ["Sun Exposure Flags"] },
+  { key: "moisture", label: "Moisture", fields: ["Soil Moisture Flags"] },
+  { key: "plantType", label: "Plant type", fields: ["Plant Type Flags"] },
+  { key: "lifeCycle", label: "Life cycle", fields: ["Life Cycle Flags"] },
+  { key: "flowering", label: "Flowers", fields: ["Flowering Months"] },
+  { key: "spread", label: "Spread", fields: ["Spread (feet)"], suffix: " ft" },
+  { key: "family", label: "Family", fields: ["Plant Family", "Family"] },
+  { key: "flowerColor", label: "Flower color", fields: ["Flower Color Flags", "Flower Color"] },
+];
+
+export const DEFAULT_PLANT_TABLE_COLUMNS = ["height", "sun", "moisture"];
+
+export default {
+  name: "PlantTable",
+  props: {
+    plants: { type: Array, default: () => [] },
+    favorites: { type: Object, required: true },
+    selectedColumns: { type: Array, default: () => DEFAULT_PLANT_TABLE_COLUMNS },
+  },
+  emits: ["open-plant", "toggle-favorite", "toggle-column", "reset-columns"],
+  data() {
+    return { columnsOpen: false };
+  },
+  computed: {
+    optionalColumns() {
+      return PLANT_TABLE_COLUMNS;
+    },
+    visibleColumns() {
+      return PLANT_TABLE_COLUMNS.filter((column) => this.selectedColumns.includes(column.key));
+    },
+  },
+  methods: {
+    isFavorite(id) {
+      return this.favorites.has(id);
+    },
+    displayValue(value) {
+      if (Array.isArray(value)) return value.length ? value.join(", ") : "—";
+      return value === null || value === undefined || value === "" ? "—" : String(value);
+    },
+    formatColumnValue(plant, column) {
+      const field = column.fields.find((name) => {
+        const value = plant[name];
+        return value !== null && value !== undefined && value !== "";
+      });
+      if (!field) return "—";
+      const value = this.displayValue(plant[field]);
+      return value === "—" || !column.suffix ? value : `${value}${column.suffix}`;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.plant-table-section {
+  width: 100%;
+  min-width: 0;
+  font-family: Roboto, sans-serif;
+}
+.table-options {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.table-options > p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 12px;
+}
+.column-picker {
+  position: relative;
+  flex: 0 0 auto;
+}
+.column-picker-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 7px 12px;
+  color: #1d2e26;
+  background: #fff;
+  border: 1px solid rgba(29, 46, 38, 0.35);
+  border-radius: 9px;
+  font: 700 13px Roboto, sans-serif;
+  cursor: pointer;
+}
+.column-picker-button .material-icons {
+  font-size: 19px;
+}
+.column-picker-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  width: min(280px, calc(100vw - 32px));
+  padding: 14px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+.column-picker-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.column-picker-menu small {
+  display: block;
+  margin: 2px 0 10px;
+  color: #666;
+}
+.column-picker-menu label {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 36px;
+  cursor: pointer;
+}
+.column-picker-menu input {
+  width: 18px;
+  height: 18px;
+  accent-color: #b74d15;
+}
+.column-reset {
+  padding: 5px;
+  color: #b74d15;
+  background: transparent;
+  border: 0;
+  font: 700 12px Roboto, sans-serif;
+  cursor: pointer;
+}
+.plant-table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid rgba(29, 46, 38, 0.18);
+  border-radius: 12px;
+  background: #fff;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.plant-table-scroll:focus-visible {
+  outline: 3px solid rgba(183, 77, 21, 0.28);
+  outline-offset: 2px;
+}
+.plant-table {
+  width: 100%;
+  min-width: 720px;
+  margin: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  color: #1d2e26;
+  font-size: 14px;
+}
+.plant-table th,
+.plant-table td {
+  padding: 12px;
+  text-align: left;
+  vertical-align: middle;
+  border: 0;
+  border-bottom: 1px solid rgba(29, 46, 38, 0.11);
+}
+.plant-table th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  color: #42534b;
+  background: #f3f1eb;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.plant-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.plant-table tbody tr:hover td {
+  background: #fbf8f2;
+}
+.favorite-column {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  width: 48px;
+  min-width: 48px;
+  padding: 4px !important;
+  text-align: center !important;
+  background: #fff;
+}
+th.favorite-column {
+  z-index: 4;
+  background: #f3f1eb;
+}
+.common-name-column {
+  min-width: 160px;
+  font-weight: 700;
+}
+.scientific-name-column {
+  min-width: 170px;
+}
+.height-column,
+.spread-column {
+  min-width: 86px;
+  white-space: nowrap;
+}
+.sun-column,
+.moisture-column,
+.lifeCycle-column,
+.plantType-column,
+.flowerColor-column {
+  min-width: 120px;
+}
+.flowering-column,
+.family-column {
+  min-width: 150px;
+}
+.table-favorite {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  color: #b74d15;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.table-favorite:hover,
+.table-favorite:focus-visible {
+  background: rgba(183, 77, 21, 0.09);
+}
+.table-favorite:focus-visible,
+.plant-name-link:focus-visible {
+  outline: 3px solid rgba(183, 77, 21, 0.3);
+  outline-offset: 1px;
+}
+.plant-name-link {
+  padding: 0;
+  color: #1d2e26;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-weight: inherit;
+  text-align: left;
+  text-decoration: underline;
+  text-decoration-color: rgba(183, 77, 21, 0.45);
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+.plant-name-link:hover {
+  color: #b74d15;
+}
+.plant-name-link.scientific-name {
+  font-style: italic;
+  font-weight: 400;
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (min-width: 900px) {
+  .table-options > p {
+    visibility: hidden;
+  }
+}
+</style>

--- a/src/composables/useGardenPlanner.ts
+++ b/src/composables/useGardenPlanner.ts
@@ -6,6 +6,7 @@ import { useLocalStorage } from './useLocalStorage';
 import { useUndoRedo } from './useUndoRedo';
 import { buildGardenDesignV1, clamp, parseGardenDesignV1, roundToIncrement, stringifyGardenDesign } from '../lib/gardenDesign';
 import type { GardenDesignV1 } from '../types/gardenDesign';
+import { trackEvent } from '../lib/analytics';
 
 const STORAGE_KEY = 'gardenPlanner:v1';
 const SNAP_INCREMENT_KEY = 'gardenPlanner:snapIncrement';
@@ -402,6 +403,10 @@ export function useGardenPlanner() {
     placedPlants.value = newPlacedPlants;
     // Create deep copy for history
     undoRedo.addState(newPlacedPlants.map(p => ({ ...p })));
+    trackEvent('planner_plant_added', {
+      placed_plant_count: newPlacedPlants.length,
+      unique_species_count: new Set(newPlacedPlants.map(p => p.plantId)).size,
+    });
 
     // Clear mobile selection after placement
     selectedPlantId.value = null;
@@ -440,17 +445,25 @@ export function useGardenPlanner() {
 
   const removePlaced = (id: string): void => {
     const newPlacedPlants = placedPlants.value.filter((p) => p.id !== id);
+    if (newPlacedPlants.length === placedPlants.value.length) return;
     placedPlants.value = newPlacedPlants;
     // Create deep copy for history
     undoRedo.addState(newPlacedPlants.map(p => ({ ...p })));
+    trackEvent('planner_plant_removed', {
+      placed_plant_count: newPlacedPlants.length,
+    });
   };
 
   const clearLayout = (): void => {
+    const removedCount = placedPlants.value.length;
     // Save current state to history before clearing so undo can restore it
     if (placedPlants.value.length > 0) {
       undoRedo.addState(placedPlants.value.map(p => ({ ...p })));
     }
     placedPlants.value = [];
+    if (removedCount > 0) {
+      trackEvent('planner_cleared', { removed_plant_count: removedCount });
+    }
   };
 
   const resetPlanner = (): void => {

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,54 @@
+const MEASUREMENT_ID = 'G-CHCN0FC8JD';
+
+let initialized = false;
+
+function analyticsEnabled() {
+  return (
+    typeof window !== 'undefined' &&
+    (process.env.NODE_ENV === 'production' || process.env.VUE_APP_GA_DEBUG === 'true')
+  );
+}
+
+export function initAnalytics() {
+  if (!analyticsEnabled() || initialized) return;
+  initialized = true;
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function gtag() {
+    window.dataLayer.push(arguments);
+  };
+
+  window.gtag('js', new Date());
+  // Vue Router reports page views below, so prevent the config call from
+  // creating a duplicate view for the initial route.
+  window.gtag('config', MEASUREMENT_ID, { send_page_view: false });
+
+  if (!document.getElementById('google-analytics-tag')) {
+    const script = document.createElement('script');
+    script.id = 'google-analytics-tag';
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}`;
+    document.head.appendChild(script);
+  }
+}
+
+export function trackEvent(name, parameters = {}) {
+  if (!analyticsEnabled()) return;
+  initAnalytics();
+  window.gtag('event', name, parameters);
+}
+
+export function trackPageView(route) {
+  if (!analyticsEnabled()) return;
+
+  // Report the route pattern rather than query strings or individual plant
+  // identifiers. This keeps searches and plant choices out of Analytics.
+  const matchedRoute = route.matched && route.matched[route.matched.length - 1];
+  const pagePath = (matchedRoute && matchedRoute.path) || route.path;
+
+  trackEvent('page_view', {
+    page_title: route.name || document.title,
+    page_location: `${window.location.origin}${pagePath}`,
+    page_path: pagePath,
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { createWebHistory } from "vue-router";
 import Tres, { extend } from '@tresjs/core';
 // @ts-ignore - project TS tooling struggles with modern package exports; runtime bundling works.
 import * as THREE from 'three';
+import { initAnalytics, trackEvent, trackPageView } from './lib/analytics';
 
 // Register ALL Three.js classes with Tres globally
 extend(THREE);
@@ -19,6 +20,11 @@ const store = storeFactory({ favorites: initialFavorites });
 // Create the app and router
 const app = createSSRApp(App);
 const router = routerFactory({ history: createWebHistory() });
+
+initAnalytics();
+router.afterEach((to) => {
+  trackPageView(to);
+});
 
 // Mount the app first
 app.use(router).use(store).use(Tres).mount('#app');
@@ -49,8 +55,26 @@ if (typeof window !== 'undefined') {
       ) {
         localStorage.setItem('favorites', JSON.stringify([...state.favorites]));
       }
+
+      if (mutation.type === 'toggleFavorite') {
+        trackEvent(
+          state.favorites.has(mutation.payload) ? 'favorite_added' : 'favorite_removed',
+          { favorite_count: state.favorites.size, method: 'single' }
+        );
+      } else if (mutation.type === 'addFavorites') {
+        const ids = Array.isArray(mutation.payload) ? mutation.payload : [mutation.payload];
+        trackEvent('favorites_added', {
+          item_count: ids.filter(Boolean).length,
+          favorite_count: state.favorites.size,
+          method: ids.length > 1 ? 'bulk' : 'single',
+        });
+      } else if (mutation.type === 'clearFavorites') {
+        trackEvent('favorites_cleared');
+      }
+
       if (mutation.type === 'setPhotoMode') {
         localStorage.setItem('photoMode', JSON.stringify(state.photoMode));
+        trackEvent('photo_mode_changed', { photo_mode: state.photoMode });
       }
     });
     


### PR DESCRIPTION
## Summary
- add a persistent Tiles/Table result layout switch
- add a responsive plant table with configurable columns and favorite actions
- compact the layout and photo-style controls across phone, tablet, and desktop breakpoints

## Verification
- npm run lint
- npm run build
- verified tile/table switching, favorites, column persistence, infinite scrolling, and responsive layouts in the browser