### PR TITLE
Add GitHub link to site header

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -22,6 +22,18 @@
             <router-link to="/planner">Planner</router-link>
             <router-link to="/map">Nurseries</router-link>
             <router-link to="/people-page">About</router-link>
+            <a
+              class="github-link"
+              href="https://github.com/CodeForPhilly/pa-wildflower-selector"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="View Choose Native Plants on GitHub"
+              title="View source on GitHub"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.1.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.57-.29-5.27-1.28-5.27-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.16 1.18A10.9 10.9 0 0 1 12 6.13c.98 0 1.95.13 2.87.39 2.2-1.49 3.16-1.18 3.16-1.18.62 1.59.23 2.76.11 3.05.74.81 1.18 1.83 1.18 3.09 0 4.41-2.71 5.38-5.29 5.67.42.36.79 1.07.79 2.16v3.24c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"/>
+              </svg>
+            </a>
           </span>
           <div class="copyright">© 2025 Choose Native Plants - USA</div>
         </menu>
@@ -155,6 +167,36 @@ a.logo-parent h1 {
   border-bottom: 2px solid #B74D15;
 }
 
+.main-nav menu a.github-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin: 20px 0 20px 4px;
+  vertical-align: middle;
+  color: currentColor;
+  border: 0;
+  border-radius: 50%;
+  opacity: 0.62;
+  transition: opacity 160ms ease, background-color 160ms ease;
+}
+
+.github-link svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.main-nav menu a.github-link:hover,
+.main-nav menu a.github-link:focus-visible {
+  border: 0;
+  background-color: rgba(255, 255, 255, 0.14);
+  opacity: 1;
+  outline: none;
+}
+
 .router-button {
   border: 0;
   background: none;
@@ -232,6 +274,19 @@ menu .copyright {
   .nav-is-open .main-nav a.router-link-exact-active {
     border-bottom: none;
     background-color: #ededed;
+  }
+  .nav-is-open .main-nav menu a.github-link {
+    display: flex;
+    width: 44px;
+    height: 44px;
+    margin: 20px auto 4px;
+    padding: 0;
+    border: 0;
+    opacity: 0.55;
+  }
+  .nav-is-open .main-nav menu a.github-link:hover,
+  .nav-is-open .main-nav menu a.github-link:focus-visible {
+    background-color: rgba(29, 46, 38, 0.08);
   }
   a .logo-substitute {
     color: black;


### PR DESCRIPTION
## Summary
- add a GitHub repository link to the primary navigation
- use an accessible label and visible focus treatment
- adapt the link for desktop and mobile navigation layouts

## Verification
- npm run lint